### PR TITLE
Specification item import from PDF

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
             <version>3.0.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.13</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/org/itsallcode/openfasttrace/importer/pdf/PdfFileImporter.java
+++ b/src/main/java/org/itsallcode/openfasttrace/importer/pdf/PdfFileImporter.java
@@ -1,0 +1,107 @@
+package org.itsallcode.openfasttrace.importer.pdf;
+
+import java.io.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.itsallcode.openfasttrace.core.SpecificationItemId;
+/*-
+ * #%L
+ * OpenFastTrace
+ * %%
+ * Copyright (C) 2016 - 2018 itsallcode.org
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+import org.itsallcode.openfasttrace.importer.*;
+import org.itsallcode.openfasttrace.importer.input.InputFile;
+
+/**
+ * This {@link Importer} supports reading PDF files
+ */
+public class PdfFileImporter implements Importer
+{
+    final static String DEFAULT_SPECITEM_PATTERN = "\\[(\\w+-\\d+)\\](.*)";
+    final static String DEFAULT_ARTIFACT_TYPE = "req";
+    final static int DEFAULT_SPECITEM_REVISION = 1;
+
+    private final InputFile file;
+    private final ImportEventListener listener;
+    protected final Pattern specItemPattern;
+
+    PdfFileImporter(final ImporterService importerService, final InputFile file,
+            final ImportEventListener listener)
+    {
+        this.file = file;
+        this.listener = listener;
+        this.specItemPattern = Pattern.compile(DEFAULT_SPECITEM_PATTERN);
+    }
+
+    @Override
+    public void runImport()
+    {
+        if (!this.file.isRealFile())
+        {
+            throw new UnsupportedOperationException(
+                    "Importing a PDF file from a stream is not supported");
+        }
+        try
+        {
+            final PDFTextStripper textStripper = new PDFTextStripper();
+            final PDDocument pdDoc = PDDocument.load(new File(this.file.getPath()));
+
+            final String pdfAsText = textStripper.getText(pdDoc);
+            final BufferedReader reader = new BufferedReader(new StringReader(pdfAsText));
+
+            String line = reader.readLine();
+            while (line != null)
+            {
+                createSpecificationItemFromLine(line);
+                line = reader.readLine();
+            }
+
+        }
+        catch (final IOException e)
+        {
+            throw new ImporterException("Error reading \"" + this.file + "\"", e);
+        }
+    }
+
+    protected void createSpecificationItemFromLine(final String line)
+    {
+        final Matcher matcher = this.specItemPattern.matcher(line);
+        if (matcher.find())
+        {
+            final String specItemName = matcher.group(1);
+            final String specItemTitle = matcher.group(2);
+
+            this.listener.beginSpecificationItem();
+
+            final SpecificationItemId specItemId = SpecificationItemId
+                    .createId(DEFAULT_ARTIFACT_TYPE, specItemName, DEFAULT_SPECITEM_REVISION);
+
+            this.listener.setId(specItemId);
+
+            this.listener.setTitle(specItemTitle.trim());
+            this.listener.appendDescription(specItemTitle.trim());
+
+            this.listener.endSpecificationItem();
+        }
+    }
+
+}

--- a/src/main/java/org/itsallcode/openfasttrace/importer/pdf/PdfFileImporterFactory.java
+++ b/src/main/java/org/itsallcode/openfasttrace/importer/pdf/PdfFileImporterFactory.java
@@ -1,0 +1,47 @@
+package org.itsallcode.openfasttrace.importer.pdf;
+
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/*-
+ * #%L
+ * OpenFastTrace
+ * %%
+ * Copyright (C) 2016 - 2018 itsallcode.org
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+import org.itsallcode.openfasttrace.importer.*;
+import org.itsallcode.openfasttrace.importer.input.InputFile;
+
+/**
+ * {@link ImporterFactory} for importing {@link ZipEntry}s of a {@link ZipFile}
+ * using a {@link PdfFileImporter}.
+ */
+public class PdfFileImporterFactory extends RegexMatchingImporterFactory
+{
+    public PdfFileImporterFactory()
+    {
+        super("(?i).*\\.(pdf)");
+    }
+
+    @Override
+    public Importer createImporter(final InputFile file, final ImportEventListener listener)
+    {
+        return new PdfFileImporter(getContext().getImporterService(), file, listener);
+    }
+}

--- a/src/main/resources/META-INF/services/org.itsallcode.openfasttrace.importer.ImporterFactory
+++ b/src/main/resources/META-INF/services/org.itsallcode.openfasttrace.importer.ImporterFactory
@@ -2,3 +2,4 @@ org.itsallcode.openfasttrace.importer.markdown.MarkdownImporterFactory
 org.itsallcode.openfasttrace.importer.specobject.SpecobjectImporterFactory
 org.itsallcode.openfasttrace.importer.tag.TagImporterFactory
 org.itsallcode.openfasttrace.importer.zip.ZipFileImporterFactory
+org.itsallcode.openfasttrace.importer.pdf.PdfFileImporterFactory

--- a/src/test/java/org/itsallcode/openfasttrace/importer/pdf/TestPdfFileImporterFactory.java
+++ b/src/test/java/org/itsallcode/openfasttrace/importer/pdf/TestPdfFileImporterFactory.java
@@ -1,0 +1,79 @@
+package org.itsallcode.openfasttrace.importer.pdf;
+
+/*-
+ * #%L
+ * OpenFastTrace
+ * %%
+ * Copyright (C) 2016 - 2018 itsallcode.org
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
+import static java.util.Arrays.asList;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+
+import org.itsallcode.openfasttrace.importer.ImporterFactoryTestBase;
+import org.itsallcode.openfasttrace.importer.ImporterService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+
+class TestPdfFileImporterFactory extends ImporterFactoryTestBase<PdfFileImporterFactory>
+{
+    @Mock
+    private ImporterService importerServiceMock;
+
+    @BeforeEach
+    public void configureMock()
+    {
+        when(this.contextMock.getImporterService()).thenReturn(this.importerServiceMock);
+    }
+
+    @Test
+    void test()
+    {
+        new PdfFileImporterFactory();
+    }
+
+    @Override
+    protected PdfFileImporterFactory createFactory()
+    {
+        return new PdfFileImporterFactory();
+    }
+
+    @Override
+    protected List<String> getSupportedFilenames()
+    {
+        return asList("blah.pdf", "a.PDF");
+    }
+
+    @Override
+    protected List<String> getUnsupportedFilenames()
+    {
+        return asList("x.java", "y.text", "z.gz", "a.zp", "y.zip");
+    }
+
+    @Test
+    void testFactoryThrowsExceptionWhenContextMissing()
+    {
+        assertThrows(NullPointerException.class,
+                () -> new PdfFileImporterFactory().createImporter(null, null),
+                "Context was not initialized");
+    }
+}

--- a/src/test/java/org/itsallcode/openfasttrace/importer/pdf/TestPdfImporter.java
+++ b/src/test/java/org/itsallcode/openfasttrace/importer/pdf/TestPdfImporter.java
@@ -1,0 +1,50 @@
+package org.itsallcode.openfasttrace.importer.pdf;
+
+import static org.mockito.Mockito.verify;
+
+import org.itsallcode.openfasttrace.core.SpecificationItemId;
+import org.itsallcode.openfasttrace.importer.ImportEventListener;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TestPdfImporter
+{
+    @Mock
+    ImportEventListener listenerMock;
+
+    @Test
+    void testImportLineWithSpecObject()
+    {
+        final PdfFileImporter importer = new PdfFileImporter(null, null, this.listenerMock);
+
+        importer.createSpecificationItemFromLine("Test 1234 [ABCD-134] This is a test title ");
+
+        verify(this.listenerMock).beginSpecificationItem();
+
+        final SpecificationItemId specItemId = SpecificationItemId.createId(
+                PdfFileImporter.DEFAULT_ARTIFACT_TYPE, "ABCD-134",
+                PdfFileImporter.DEFAULT_SPECITEM_REVISION);
+        verify(this.listenerMock).setId(specItemId);
+
+        verify(this.listenerMock).setTitle("This is a test title");
+        verify(this.listenerMock).appendDescription("This is a test title");
+
+        verify(this.listenerMock).endSpecificationItem();
+    }
+
+    @Test
+    void testImportLineWithoutSpecObject()
+    {
+        final PdfFileImporter importer = new PdfFileImporter(null, null, this.listenerMock);
+
+        importer.createSpecificationItemFromLine("Test 1234 ABCD-134 This is a test title ");
+
+        verify(this.listenerMock, Mockito.never()).beginSpecificationItem();
+        verify(this.listenerMock, Mockito.never()).endSpecificationItem();
+    }
+
+}

--- a/src/test/java/org/itsallcode/openfasttrace/importer/pdf/TestPdfImporter.java
+++ b/src/test/java/org/itsallcode/openfasttrace/importer/pdf/TestPdfImporter.java
@@ -1,5 +1,27 @@
 package org.itsallcode.openfasttrace.importer.pdf;
 
+/*-
+ * #%L
+ * OpenFastTrace
+ * %%
+ * Copyright (C) 2016 - 2018 itsallcode.org
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/gpl-3.0.html>.
+ * #L%
+ */
+
 import static org.mockito.Mockito.verify;
 
 import org.itsallcode.openfasttrace.core.SpecificationItemId;


### PR DESCRIPTION
This is a first attempt to import specification items from PDF.
It uses apache pdfbox to convert the PDF to text and then extracts specification items based on a regular expression.
Currently this is hardcoded to requirements in the form of [ABCD-123].

I want to make things like the pattern, artifact type, revision number, needs etc. configurable but I could not find out how to send parameters from the commandline to the importer.
If this is at all possible, could someone give me a hint, please?

Another thing I don't understand is why the Title does not appear in the converted output XML even though I'm calling setTitle().
