### PR TITLE
Fixed links to contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,4 +94,4 @@ For more details about how to run OFT please consult the [user guide](doc/user_g
 
 If you want to learn how to build OpenFastTrace, please check our [Developer Guide](doc/developer_guide.md).
 
-You would like to contribute to OFT? Please check out our [Contributor Guide](CONTRIBUTION.md) to get started. 
+You would like to contribute to OFT? Please check out our [Contributor Guide](CONTRIBUTING.md) to get started. 

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -2,7 +2,7 @@
 
 This document contains technical information for developers contributing to OpenFastTrace (short OFT).
 
-If you want to know more about how to contribute to OFT, please check out our [Contributor Guide](../CONTRIBUTION.md).
+If you want to know more about how to contribute to OFT, please check out our [Contributor Guide](../CONTRIBUTING.md).
 
 ## Getting the OpenFastTrace Library
 


### PR DESCRIPTION
Links to the contribution guide were broken at two places.