### PR TITLE
Using Temurin builds of OpenJDK in GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
     - uses: actions/setup-java@v2
       with:
-        distribution: 'zulu'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
 
     - name: Cache local Maven repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
 
     - uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'zulu'
         java-version: ${{ matrix.java }}
 
     - name: Cache local Maven repository

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,7 +19,7 @@ jobs:
 
     - uses: actions/setup-java@v2
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 11
 
     - name: Cache local Maven repository


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued Since July 2021. When using Zulu you get all the latest updated builds (TCK tested) for all versions of OpenJDK. 🥇  