### PR TITLE
#326: Import files with `.cs` extension

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added support for C# files with postfix `.cs` [#326](https://github.com/itsallcode/openfasttrace/issues/315) / [PR #316](https://github.com/itsallcode/openfasttrace/pull/326)
+- Added support for C# files with postfix `.cs` [#326](https://github.com/itsallcode/openfasttrace/issues/326) / [PR #327](https://github.com/itsallcode/openfasttrace/pull/327)
 
 ## [3.5.0] - 2022-03-17
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added support for C# files with postfix `.cs` [#326](https://github.com/itsallcode/openfasttrace/issues/315) / [PR #316](https://github.com/itsallcode/openfasttrace/pull/326)
+
 ## [3.5.0] - 2022-03-17
 
 ### Updated

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -462,7 +462,7 @@ recognized file types:
 
 * C (`.c`, `.h`)
 * C++ (`.C`, `.cpp`, `.c++`, `.cc`, `.H`, `.hpp`, `.h++`, `.hh`)
-* C# (`.c#`)
+* C# (`.c#`, `cs`)
 * Database related (`.sql`, `.pls`)
 * Configuration files (`.cfg`, `.conf`, `.ini`)
 * [Go](https://golang.org/) (`.go`)

--- a/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/TagImporterFactory.java
+++ b/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/TagImporterFactory.java
@@ -43,7 +43,7 @@ public class TagImporterFactory extends ImporterFactory
     private static final List<String> SUPPORTED_DEFAULT_EXTENSIONS = Arrays.asList( //
             "bat", // Windows batch files
             "c", "C", "cc", "cpp", "c++", "h", "H", "h++", "hh", "hpp", // C/C++
-            "c#", // C#
+            "c#", "cs", // C#
             "cfg", "conf", "ini", // configuration files
             "go", // Go
             "groovy", // Groovy

--- a/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporterFactory.java
+++ b/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporterFactory.java
@@ -48,7 +48,7 @@ class TestTagImporterFactory extends ImporterFactoryTestBase<TagImporterFactory>
     {
         return asList("file.java", "FILE.java", "file.md.java", "foo.bash", "foo.bar.bash",
                 "foo.bat", "foo.java", "foo.c", "foo.C", "foo.c++", "foo.c#", "foo.cc", "foo.cfg",
-                "foo.conf", "foo.cpp", "foo.groovy", "foo.h", "foo.H", "foo.hh", "foo.h++",
+                "foo.conf", "foo.cpp", "foo.cs", "foo.groovy", "foo.h", "foo.H", "foo.hh", "foo.h++",
                 "foo.htm", "foo.html", "foo.ini", "foo.js", "foo.json", "foo.lua", "foo.m",
                 "foo.mm", "foo.php", "foo.pl", "foo.pls", "foo.pm", "foo.py", "foo.sql", "foo.r",
                 "foo.rs", "foo.sh", "foo.yaml", "foo.xhtml", "foo.zsh", "foo.clj", "foo.kt", "foo.scala",


### PR DESCRIPTION
For C# files with `.cs` extension are now supported additionally to `.c#` extension. Closess #326.