### PR TITLE
Ignore spaces after items in "Needs:" and "Tags:" lists

### DIFF
--- a/api/src/main/java/org/itsallcode/openfasttrace/api/core/SpecificationItemId.java
+++ b/api/src/main/java/org/itsallcode/openfasttrace/api/core/SpecificationItemId.java
@@ -137,11 +137,7 @@ public class SpecificationItemId implements Comparable<SpecificationItemId>
         {
             return false;
         }
-        if ((other.revision != REVISION_WILDCARD) && (this.revision != other.revision))
-        {
-            return false;
-        }
-        return true;
+        return (other.revision == REVISION_WILDCARD) || (this.revision == other.revision);
     }
 
     @Override

--- a/api/src/main/java/org/itsallcode/openfasttrace/api/core/TracedLink.java
+++ b/api/src/main/java/org/itsallcode/openfasttrace/api/core/TracedLink.java
@@ -100,10 +100,6 @@ public final class TracedLink
         {
             return false;
         }
-        if (this.status != other.status)
-        {
-            return false;
-        }
-        return true;
+        return this.status == other.status;
     }
 }

--- a/core/src/test/java/org/itsallcode/openfasttrace/core/matcher/SpecificationItemIdMatcher.java
+++ b/core/src/test/java/org/itsallcode/openfasttrace/core/matcher/SpecificationItemIdMatcher.java
@@ -8,10 +8,9 @@ import org.hamcrest.Factory;
 import org.hamcrest.Matcher;
 import org.hamcrest.collection.IsEmptyIterable;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
+import org.itsallcode.matcher.config.ConfigurableMatcher;
+import org.itsallcode.matcher.config.MatcherConfig;
 import org.itsallcode.openfasttrace.api.core.SpecificationItemId;
-
-import com.github.hamstercommunity.matcher.config.ConfigurableMatcher;
-import com.github.hamstercommunity.matcher.config.MatcherConfig;
 
 /**
  * {@link Matcher} for {@link SpecificationItemId}

--- a/core/src/test/java/org/itsallcode/openfasttrace/core/matcher/SpecificationItemMatcher.java
+++ b/core/src/test/java/org/itsallcode/openfasttrace/core/matcher/SpecificationItemMatcher.java
@@ -5,15 +5,12 @@ import static java.util.stream.Collectors.toList;
 import java.util.Collection;
 import java.util.stream.StreamSupport;
 
-import org.hamcrest.Factory;
-import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
+import org.hamcrest.*;
 import org.hamcrest.collection.IsEmptyIterable;
 import org.hamcrest.collection.IsIterableContainingInAnyOrder;
+import org.itsallcode.matcher.config.ConfigurableMatcher;
+import org.itsallcode.matcher.config.MatcherConfig;
 import org.itsallcode.openfasttrace.api.core.SpecificationItem;
-
-import com.github.hamstercommunity.matcher.config.ConfigurableMatcher;
-import com.github.hamstercommunity.matcher.config.MatcherConfig;
 
 /**
  * {@link Matcher} for {@link SpecificationItem}

--- a/doc/changes/changes.md
+++ b/doc/changes/changes.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [3.7.2](changes_3.7.2.md)
 * [3.7.1](changes_3.7.1.md)
 * [3.7.0](changes_3.7.0.md)
 * [3.6.0](changes_3.6.0.md)

--- a/doc/changes/changes_3.7.2.md
+++ b/doc/changes/changes_3.7.2.md
@@ -1,0 +1,11 @@
+# OpenFastTrace 3.7.2, released 2024-??-??
+
+Code name: Bugfixes for parsing `Needs` and `Tags` in MarkDown
+
+## Summary
+
+This release fixes parsing of `Needs` and `Tags` entries in MarkDown. OFT now ignores whitespace in both and also correctly parses `Tags` in beginning of a requirement item.
+
+## Bugfixes
+
+* #373: Ignore spaces after items in "Needs:" and "Tags:" lists (thanks to [@sambishop](https://github.com/sambishop) for his contribution!)

--- a/doc/changes/changes_3.7.2.md
+++ b/doc/changes/changes_3.7.2.md
@@ -1,10 +1,10 @@
 # OpenFastTrace 3.7.2, released 2024-??-??
 
-Code name: Bugfixes for parsing `Needs` and `Tags` in MarkDown
+Code name: Bugfixes for parsing `Needs` and `Tags` in Markdown
 
 ## Summary
 
-This release fixes parsing of `Needs` and `Tags` entries in MarkDown. OFT now ignores whitespace in both and also correctly parses `Tags` in beginning of a requirement item.
+This release fixes parsing of `Needs` and `Tags` entries in Markdown. OFT now ignores whitespace in both and also correctly parses `Tags` in beginning of a requirement item.
 
 ## Bugfixes
 

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -134,19 +134,19 @@ Add the following to your `~/.m2/settings.xml`:
 ### Prepare the Release
 
 1. Checkout the `main` branch.
-1. Create a new "prepare-release" branch.
-1. Update version in
-  * `openfasttrace-parent/pom.xml` (`revision` property)
-  * `README.md`
-  * `doc/developer_guide.md`
-1. Add changes in new version to `CHANGELOG.md` and update the release date.
-1. Verify that build runs successfully:
+2. Create a new "prepare-release" branch.
+3. Update version in
+    * `openfasttrace-parent/pom.xml` (`revision` property)
+    * `README.md`
+    * `doc/developer_guide.md`
+4. Add changes in new version to `doc/changes/changes.md` and `doc/changes/changes_$VERSION.md` and update the release date.
+5. Verify that build runs successfully:
 
     ```bash
     mvn clean verify
     ```
-1. Commit and push changes.
-1. Create a new Pull Request, have it reviewed and merged.
+6. Commit and push changes.
+7. Create a new Pull Request, have it reviewed and merged.
 
 ### Perform the Release
 

--- a/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MarkdownImporter.java
+++ b/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MarkdownImporter.java
@@ -8,9 +8,7 @@ import java.util.logging.Logger;
 
 import org.itsallcode.openfasttrace.api.core.ItemStatus;
 import org.itsallcode.openfasttrace.api.core.SpecificationItemId;
-import org.itsallcode.openfasttrace.api.importer.ImportEventListener;
-import org.itsallcode.openfasttrace.api.importer.Importer;
-import org.itsallcode.openfasttrace.api.importer.ImporterException;
+import org.itsallcode.openfasttrace.api.importer.*;
 import org.itsallcode.openfasttrace.api.importer.input.InputFile;
 
 class MarkdownImporter implements Importer
@@ -42,10 +40,10 @@ class MarkdownImporter implements Importer
         transition(SPEC_ITEM  , DEPENDS    , MdPattern.DEPENDS    , () -> {}                                              ),
         transition(SPEC_ITEM  , NEEDS      , MdPattern.NEEDS_INT  , this::addNeeds                                        ),
         transition(SPEC_ITEM  , NEEDS      , MdPattern.NEEDS      , () -> {}                                              ),
-        transition(SPEC_ITEM  , DESCRIPTION, MdPattern.DESCRIPTION, this::beginDescription                                ),
-        transition(SPEC_ITEM  , DESCRIPTION, MdPattern.NOT_EMPTY  , this::beginDescription                                ),
         transition(SPEC_ITEM  , TAGS       , MdPattern.TAGS_INT   , this::addTag                                          ),
         transition(SPEC_ITEM  , TAGS       , MdPattern.TAGS       , () -> {}                                              ),
+        transition(SPEC_ITEM  , DESCRIPTION, MdPattern.DESCRIPTION, this::beginDescription                                ),
+        transition(SPEC_ITEM  , DESCRIPTION, MdPattern.NOT_EMPTY  , this::beginDescription                                ),
     
         transition(DESCRIPTION, SPEC_ITEM  , MdPattern.ID         , () -> {endDescription(); beginItem();}                ),
         transition(DESCRIPTION, TITLE      , MdPattern.TITLE      , () -> {endDescription(); endItem(); rememberTitle(); }),

--- a/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MarkdownImporter.java
+++ b/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MarkdownImporter.java
@@ -301,9 +301,9 @@ class MarkdownImporter implements Importer
     private void addNeeds()
     {
         final String artifactTypes = this.stateMachine.getLastToken();
-        for (final String artifactType : artifactTypes.split(",\\s*"))
+        for (final String artifactType : artifactTypes.split(","))
         {
-            this.listener.addNeededArtifactType(artifactType);
+            this.listener.addNeededArtifactType(artifactType.trim());
         }
     }
 

--- a/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MarkdownImporter.java
+++ b/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MarkdownImporter.java
@@ -326,9 +326,9 @@ class MarkdownImporter implements Importer
     private void addTag()
     {
         final String tags = this.stateMachine.getLastToken();
-        for (final String tag : tags.split(",\\s*"))
+        for (final String tag : tags.split(","))
         {
-            this.listener.addTag(tag);
+            this.listener.addTag(tag.trim());
         }
     }
 

--- a/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MdPattern.java
+++ b/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MdPattern.java
@@ -46,7 +46,7 @@ enum MdPattern
     NOT_EMPTY("([^\n\r]+)"),
     RATIONALE("Rationale:\\s*"),
     STATUS("Status:\\s*(approved|proposed|draft)\\s*"),
-    TAGS_INT("Tags:\\s*(\\w+(?:,\\s*\\w+)*)"),
+    TAGS_INT("Tags:(\\s*\\w+\\s*(?:,\\s*\\w+\\s*)*)"),
     TAGS("Tags:\\s*"),
     TAG_ENTRY(PatternConstants.UP_TO_3_WHITESPACES + PatternConstants.BULLETS
             + "\\s*" //

--- a/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MdPattern.java
+++ b/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MdPattern.java
@@ -37,7 +37,7 @@ enum MdPattern
             + SpecificationItemId.ID_PATTERN
             + ").*?"),
     ID("`?((?:" + SpecificationItemId.ID_PATTERN + ")|(?:" + SpecificationItemId.LEGACY_ID_PATTERN + "))`?.*"),
-    NEEDS_INT("Needs:\\s*(\\w+(?:,\\s*\\w+)*)"),
+    NEEDS_INT("Needs:(\\s*\\w+\\s*(?:,\\s*\\w+\\s*)*)"),
     NEEDS("Needs:\\s*"),
     NEEDS_REF(PatternConstants.UP_TO_3_WHITESPACES + PatternConstants.BULLETS
             + "(?:.*\\W)?" //

--- a/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/ITMarkdownImporter.java
+++ b/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/ITMarkdownImporter.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Stream;
 
+import org.itsallcode.matcher.auto.AutoMatcher;
 import org.itsallcode.openfasttrace.api.core.*;
 import org.itsallcode.openfasttrace.api.importer.Importer;
 import org.itsallcode.openfasttrace.api.importer.SpecificationListBuilder;
@@ -21,7 +22,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import com.github.hamstercommunity.matcher.auto.AutoMatcher;
 
 class ITMarkdownImporter
 {

--- a/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/ITMarkdownImporter.java
+++ b/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/ITMarkdownImporter.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 class ITMarkdownImporter
 {
+    private static final String NL = System.lineSeparator();
     private static final String TAG2 = "Tag2";
     private static final String TAG1 = "Tag1";
     private static final String FILENAME = "file name";
@@ -34,9 +35,9 @@ class ITMarkdownImporter
     {
         assertThat(runImporterOnText(createCompleteSpecificationItemInMarkdownFormat()),
                 AutoMatcher.contains(SpecificationItem.builder().id(ID1).title("Requirement Title")
-                        .comment("Comment\nMore comment")
-                        .description("Description\n\nMore description")
-                        .rationale("Rationale\nMore rationale")
+                        .comment("Comment" + NL + "More comment")
+                        .description("Description" + NL + NL + "More description")
+                        .rationale("Rationale" + NL + "More rationale")
                         .addNeedsArtifactType("artA").addNeedsArtifactType("artB")
                         .addCoveredId(SpecificationItemId.parseId(COVERED_ID1))
                         .addCoveredId(SpecificationItemId.parseId(COVERED_ID2))
@@ -118,9 +119,9 @@ class ITMarkdownImporter
                 AutoMatcher.contains(SpecificationItem.builder().id(SpecificationItemId.parseId(LEGACY_ID))
                         .title("Requirement Title")
                         .status(ItemStatus.PROPOSED)
-                        .comment("Comment\nMore comment")
-                        .description("Description\n\nMore description")
-                        .rationale("Rationale\nMore rationale")
+                        .comment("Comment" + NL + "More comment")
+                        .description("Description" + NL + NL + "More description")
+                        .rationale("Rationale" + NL + "More rationale")
                         .addNeedsArtifactType("artA").addNeedsArtifactType("artB")
                         .addCoveredId(SpecificationItemId.parseId(LEGACY_COVERED_ID1))
                         .addCoveredId(SpecificationItemId.parseId(LEGACY_COVERED_ID2))
@@ -242,6 +243,5 @@ class ITMarkdownImporter
                 Arguments.of("Tags:\n * req\n * dsn\n", List.of("req", "dsn")),
                 Arguments.of("Tags:\n* req \n\t* dsn ", List.of("req", "dsn")),
                 Arguments.of("Tags:\n* req\n* dsn", List.of("req", "dsn")));
-
     }
 }

--- a/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/ITMarkdownImporter.java
+++ b/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/ITMarkdownImporter.java
@@ -1,0 +1,247 @@
+package org.itsallcode.openfasttrace.importer.markdown;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.itsallcode.openfasttrace.importer.markdown.MarkdownTestConstants.*;
+
+import java.io.BufferedReader;
+import java.io.StringReader;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.itsallcode.openfasttrace.api.core.*;
+import org.itsallcode.openfasttrace.api.importer.Importer;
+import org.itsallcode.openfasttrace.api.importer.SpecificationListBuilder;
+import org.itsallcode.openfasttrace.api.importer.input.InputFile;
+import org.itsallcode.openfasttrace.testutil.importer.input.StreamInput;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.github.hamstercommunity.matcher.auto.AutoMatcher;
+
+class ITMarkdownImporter
+{
+    private static final String TAG2 = "Tag2";
+    private static final String TAG1 = "Tag1";
+    private static final String FILENAME = "file name";
+
+    @Test
+    void testFindRequirement()
+    {
+        assertThat(runImporterOnText(createCompleteSpecificationItemInMarkdownFormat()),
+                AutoMatcher.contains(SpecificationItem.builder().id(ID1).title("Requirement Title")
+                        .comment("Comment\nMore comment")
+                        .description("Description\n\nMore description")
+                        .rationale("Rationale\nMore rationale")
+                        .addNeedsArtifactType("artA").addNeedsArtifactType("artB")
+                        .addCoveredId(SpecificationItemId.parseId(COVERED_ID1))
+                        .addCoveredId(SpecificationItemId.parseId(COVERED_ID2))
+                        .addDependOnId(SpecificationItemId.parseId(DEPENDS_ON_ID1))
+                        .addDependOnId(SpecificationItemId.parseId(DEPENDS_ON_ID2))
+                        .location("file name", 2)
+                        .build()));
+
+    }
+
+    // [utest->dsn~md.needs-coverage-list-compact~1]
+    private String createCompleteSpecificationItemInMarkdownFormat()
+    {
+        return "# " + TITLE //
+                + "\n" //
+                + "`" + ID1 + "` <a id=\"" + ID1 + "\"></a>" //
+                + "\n" //
+                + DESCRIPTION_LINE1 + "\n" //
+                + DESCRIPTION_LINE2 + "\n" //
+                + DESCRIPTION_LINE3 + "\n" //
+                + "\nRationale:\n" //
+                + RATIONALE_LINE1 + "\n" //
+                + RATIONALE_LINE2 + "\n" //
+                + "\nCovers:\n\n" //
+                + "  * " + COVERED_ID1 + "\n" //
+                + " + " + "[Link to baz2](#" + COVERED_ID2 + ")\n" //
+                + "\nDepends:\n\n" //
+                + "  + " + DEPENDS_ON_ID1 + "\n" //
+                + "  - " + DEPENDS_ON_ID2 + "\n" //
+                + "\nComment:\n\n" //
+                + COMMENT_LINE1 + "\n" //
+                + COMMENT_LINE2 + "\n" //
+                + "\nNeeds: " + NEEDS_ARTIFACT_TYPE1 //
+                + " , " + NEEDS_ARTIFACT_TYPE2 + " ";
+    }
+
+    private List<SpecificationItem> runImporterOnText(final String text)
+    {
+        final BufferedReader reader = new BufferedReader(new StringReader(text));
+        final InputFile file = StreamInput.forReader(Paths.get(FILENAME), reader);
+        final SpecificationListBuilder specItemBuilder = SpecificationListBuilder.create();
+        final Importer importer = new MarkdownImporterFactory().createImporter(file,
+                specItemBuilder);
+        importer.runImport();
+        return specItemBuilder.build();
+    }
+
+    @Test
+    void testTwoConsecutiveSpecificationItems()
+    {
+        assertThat(runImporterOnText(createTwoConsecutiveItemsInMarkdownFormat()),
+                AutoMatcher
+                        .contains(SpecificationItem.builder().id(ID1).title(TITLE).location("file name", 2).build(),
+                                SpecificationItem.builder().id(ID2).title("").location("file name", 4).build()));
+    }
+
+    private String createTwoConsecutiveItemsInMarkdownFormat()
+    {
+        return "# " + TITLE //
+                + "\n" //
+                + ID1 + "\n" //
+                + "\n" + ID2 + "\n" //
+                + "# Irrelevant Title";
+    }
+
+    @Test
+    void testSingleNeeds()
+    {
+        final String singleNeedsItem = "`foo~bar~1`\n\nNeeds: " + NEEDS_ARTIFACT_TYPE1;
+        final List<SpecificationItem> items = runImporterOnText(singleNeedsItem);
+        assertThat(items.get(0).getNeedsArtifactTypes(), contains(NEEDS_ARTIFACT_TYPE1));
+    }
+
+    @Test
+    void testFindLegacyRequirement()
+    {
+        final String completeItem = createCompleteSpecificationItemInLegacyMarkdownFormat();
+        assertThat(runImporterOnText(completeItem),
+                AutoMatcher.contains(SpecificationItem.builder().id(SpecificationItemId.parseId(LEGACY_ID))
+                        .title("Requirement Title")
+                        .status(ItemStatus.PROPOSED)
+                        .comment("Comment\nMore comment")
+                        .description("Description\n\nMore description")
+                        .rationale("Rationale\nMore rationale")
+                        .addNeedsArtifactType("artA").addNeedsArtifactType("artB")
+                        .addCoveredId(SpecificationItemId.parseId(LEGACY_COVERED_ID1))
+                        .addCoveredId(SpecificationItemId.parseId(LEGACY_COVERED_ID2))
+                        .addDependOnId(SpecificationItemId.parseId(LEGACY_DEPENDS_ON_ID1))
+                        .addDependOnId(SpecificationItemId.parseId(LEGACY_DEPENDS_ON_ID2))
+                        .addTag("Tag1").addTag("Tag2")
+                        .location("file name", 2)
+                        .build()));
+    }
+
+    // [utest->dsn~md.needs-coverage-list~2]
+    private String createCompleteSpecificationItemInLegacyMarkdownFormat()
+    {
+        return "# " + TITLE //
+                + "\n" //
+                + "`" + LEGACY_ID + "`" //
+                + "\n" //
+                + "\nStatus: proposed\n" //
+                + "\nDescription:\n" + DESCRIPTION_LINE1 + "\n" //
+                + DESCRIPTION_LINE2 + "\n" //
+                + DESCRIPTION_LINE3 + "\n" //
+                + "\nRationale:\n" //
+                + RATIONALE_LINE1 + "\n" //
+                + RATIONALE_LINE2 + "\n" //
+                + "\nDepends:\n\n" //
+                + "  + `" + LEGACY_DEPENDS_ON_ID1 + "`\n" //
+                + "  - `" + LEGACY_DEPENDS_ON_ID2 + "`\n" //
+                + "\nCovers:\n\n" //
+                + "  * `" + LEGACY_COVERED_ID1 + "`\n" //
+                + " + `" + LEGACY_COVERED_ID2 + "`\n" //
+                + "\nComment:\n\n" //
+                + COMMENT_LINE1 + "\n" //
+                + COMMENT_LINE2 + "\n" //
+                + "\nNeeds:\n" //
+                + "   * " + NEEDS_ARTIFACT_TYPE1 + "\n"//
+                + "+ " + NEEDS_ARTIFACT_TYPE2 + "\n" //
+                + "\nTags: " + TAG1 + ", " + TAG2;
+
+        // + "\nTags:\n" //
+        // + " * " + TAG1 + "\n" //
+        // + " + " + TAG2 + "";
+    }
+
+    // [utest->dsn~md.artifact-forwarding-notation~1]
+    @Test
+    void testForwardRequirement()
+    {
+        final List<SpecificationItem> items = runImporterOnText("arch-->dsn:req~foobar~2\n" //
+                + "   * `dsn --> impl, utest,itest : arch~bar.zoo~123`");
+        assertThat(items,
+                AutoMatcher.contains(SpecificationItem.builder().id(SpecificationItemId.parseId("arch~foobar~2"))
+                        .forwards(true)
+                        .addCoveredId(SpecificationItemId.parseId("req~foobar~2"))
+                        .addNeedsArtifactType("dsn")
+                        .build(),
+                        SpecificationItem.builder().id(SpecificationItemId.parseId("dsn~bar.zoo~123"))
+                                .addCoveredId(SpecificationItemId.parseId("arch~bar.zoo~123"))
+                                .addNeedsArtifactType("impl").addNeedsArtifactType("utest")
+                                .addNeedsArtifactType("itest")
+                                .forwards(true)
+                                .build()));
+    }
+
+    // [utest->dsn~md.specification-item-title~1]
+    @Test
+    void testFindTitleAfterTitle()
+    {
+        assertThat(runImporterOnText("## This title should be ignored\n\n" //
+                + "### Title\n" //
+                + "`a~b~1`"),
+                AutoMatcher.contains(SpecificationItem.builder().id(SpecificationItemId.parseId("a~b~1"))
+                        .title("Title").location("file name", 4)
+                        .build()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("needsCoverage")
+    void testNeedsCoverage(final String mdContent, final List<String> expected)
+    {
+        final List<SpecificationItem> items = runImporterOnText("`a~b~1`\n" + mdContent);
+        assertThat(items.get(0).getNeedsArtifactTypes(), equalTo(expected));
+    }
+
+    static Stream<Arguments> needsCoverage()
+    {
+        return Stream.of(
+                Arguments.of("Needs: req , dsn ", List.of("req", "dsn")),
+                Arguments.of("Needs: req ", List.of("req")),
+                Arguments.of("Needs: req,dsn ", List.of("req", "dsn")),
+                Arguments.of("Needs: req ,dsn", List.of("req", "dsn")),
+                Arguments.of("Needs: req,dsn", List.of("req", "dsn")),
+                Arguments.of("Needs:  req,\tdsn\n", List.of("req", "dsn")),
+                Arguments.of("Needs:req,dsn", List.of("req", "dsn")),
+                Arguments.of("Needs:\n* req\n* dsn", List.of("req", "dsn")),
+                Arguments.of("Needs:\n  * req\n  * dsn", List.of("req", "dsn")),
+                Arguments.of("Needs:\n*  req \n\t*  dsn ", List.of("req", "dsn")),
+                Arguments.of("Needs:\n* req\n* dsn", List.of("req", "dsn")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("tags")
+    void testTags(final String mdContent, final List<String> expected)
+    {
+        final List<SpecificationItem> items = runImporterOnText("`a~b~1`\n" + mdContent);
+        assertThat(items.get(0).getTags(), equalTo(expected));
+    }
+
+    static Stream<Arguments> tags()
+    {
+        return Stream.of(
+                Arguments.of("Tags: req , dsn ", List.of("req", "dsn")),
+                Arguments.of("Tags: req ", List.of("req")),
+                Arguments.of("Tags: req,dsn ", List.of("req", "dsn")),
+                Arguments.of("Tags: req ,dsn", List.of("req", "dsn")),
+                Arguments.of("Tags: req,dsn", List.of("req", "dsn")),
+                Arguments.of("Tags: req,\tdsn\n", List.of("req", "dsn")),
+                Arguments.of("Tags:req,dsn", List.of("req", "dsn")),
+                Arguments.of("Tags:\n* req\n* dsn", List.of("req", "dsn")),
+                Arguments.of("Tags:\n * req\n * dsn\n", List.of("req", "dsn")),
+                Arguments.of("Tags:\n* req \n\t* dsn ", List.of("req", "dsn")),
+                Arguments.of("Tags:\n* req\n* dsn", List.of("req", "dsn")));
+
+    }
+}

--- a/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/ITMarkdownImporter.java
+++ b/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/ITMarkdownImporter.java
@@ -159,10 +159,6 @@ class ITMarkdownImporter
                 + "   * " + NEEDS_ARTIFACT_TYPE1 + "\n"//
                 + "+ " + NEEDS_ARTIFACT_TYPE2 + "\n" //
                 + "\nTags: " + TAG1 + ", " + TAG2;
-
-        // + "\nTags:\n" //
-        // + " * " + TAG1 + "\n" //
-        // + " + " + TAG2 + "";
     }
 
     // [utest->dsn~md.artifact-forwarding-notation~1]

--- a/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/TestMarkdownImporter.java
+++ b/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/TestMarkdownImporter.java
@@ -86,7 +86,7 @@ class TestMarkdownImporter
                 + COMMENT_LINE1 + "\n" //
                 + COMMENT_LINE2 + "\n" //
                 + "\nNeeds: " + NEEDS_ARTIFACT_TYPE1 //
-                + ", " + NEEDS_ARTIFACT_TYPE2;
+                + " , " + NEEDS_ARTIFACT_TYPE2 + " ";
     }
 
     private void runImporterOnText(final String text)

--- a/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/TestMarkdownImporter.java
+++ b/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/TestMarkdownImporter.java
@@ -3,13 +3,9 @@ package org.itsallcode.openfasttrace.importer.markdown;
 import static org.itsallcode.openfasttrace.importer.markdown.MarkdownAsserts.assertMatch;
 import static org.itsallcode.openfasttrace.importer.markdown.MarkdownAsserts.assertMismatch;
 import static org.itsallcode.openfasttrace.importer.markdown.MarkdownTestConstants.*;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
-import java.io.BufferedReader;
-import java.io.Reader;
-import java.io.StringReader;
+import java.io.*;
 import java.nio.file.Paths;
 
 import org.itsallcode.openfasttrace.api.core.ItemStatus;
@@ -53,6 +49,20 @@ class TestMarkdownImporter
     {
         assertMatch(MdPattern.TITLE, "#Title", "# Title", "###### Title", "#   Title");
         assertMismatch(MdPattern.TITLE, "Title", "Title #", " # Title");
+    }
+
+    @Test
+    void testIdentifyNeeds()
+    {
+        assertMatch(MdPattern.NEEDS_INT, "Needs: req, dsn", "Needs:req,dsn", "Needs:  \treq , dsn ");
+        assertMismatch(MdPattern.NEEDS_INT, "Needs:");
+    }
+
+    @Test
+    void testIdentifyTags()
+    {
+        assertMatch(MdPattern.TAGS_INT, "Tags: req, dsn", "Tags:req,dsn", "Tags:  \treq , dsn ");
+        assertMismatch(MdPattern.TAGS_INT, "Tags:");
     }
 
     @Test

--- a/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/TestMarkdownImporter.java
+++ b/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/TestMarkdownImporter.java
@@ -3,6 +3,7 @@ package org.itsallcode.openfasttrace.importer.markdown;
 import static org.itsallcode.openfasttrace.importer.markdown.MarkdownAsserts.assertMatch;
 import static org.itsallcode.openfasttrace.importer.markdown.MarkdownAsserts.assertMismatch;
 import static org.itsallcode.openfasttrace.importer.markdown.MarkdownTestConstants.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.Mockito.*;
 
 import java.io.*;
@@ -37,32 +38,33 @@ class TestMarkdownImporter
     @Test
     void testIdentifyId()
     {
-        assertMatch(MdPattern.ID, "req~foo~1<a id=\"req~foo~1\"></a>", "a~b~0", "req~test~1",
-                "req~test~999", "req~test.requirement~1", "req~test_underscore~1",
-                "`req~test1~1`arbitrary text");
-        assertMismatch(MdPattern.ID, "test~1", "req-test~1", "req~4test~1");
+        assertAll(
+                () -> assertMatch(MdPattern.ID, "req~foo~1<a id=\"req~foo~1\"></a>", "a~b~0", "req~test~1",
+                        "req~test~999", "req~test.requirement~1", "req~test_underscore~1",
+                        "`req~test1~1`arbitrary text"),
+                () -> assertMismatch(MdPattern.ID, "test~1", "req-test~1", "req~4test~1"));
     }
 
     // [utest->dsn~md.specification-item-title~1]
     @Test
     void testIdentifyTitle()
     {
-        assertMatch(MdPattern.TITLE, "#Title", "# Title", "###### Title", "#   Title");
-        assertMismatch(MdPattern.TITLE, "Title", "Title #", " # Title");
+        assertAll(() -> assertMatch(MdPattern.TITLE, "#Title", "# Title", "###### Title", "#   Title"),
+                () -> assertMismatch(MdPattern.TITLE, "Title", "Title #", " # Title"));
     }
 
     @Test
     void testIdentifyNeeds()
     {
-        assertMatch(MdPattern.NEEDS_INT, "Needs: req, dsn", "Needs:req,dsn", "Needs:  \treq , dsn ");
-        assertMismatch(MdPattern.NEEDS_INT, "Needs:");
+        assertAll(() -> assertMatch(MdPattern.NEEDS_INT, "Needs: req, dsn", "Needs:req,dsn", "Needs:  \treq , dsn "),
+                () -> assertMismatch(MdPattern.NEEDS_INT, "Needs:"));
     }
 
     @Test
     void testIdentifyTags()
     {
-        assertMatch(MdPattern.TAGS_INT, "Tags: req, dsn", "Tags:req,dsn", "Tags:  \treq , dsn ");
-        assertMismatch(MdPattern.TAGS_INT, "Tags:");
+        assertAll(() -> assertMatch(MdPattern.TAGS_INT, "Tags: req, dsn", "Tags:req,dsn", "Tags:  \treq , dsn "),
+                () -> assertMismatch(MdPattern.TAGS_INT, "Tags:"));
     }
 
     @Test

--- a/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporter.java
+++ b/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporter.java
@@ -2,7 +2,6 @@ package org.itsallcode.openfasttrace.importer.tag;
 
 import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
-
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 
@@ -13,6 +12,7 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.zip.CRC32;
 
+import org.itsallcode.matcher.auto.AutoMatcher;
 import org.itsallcode.openfasttrace.api.core.SpecificationItem;
 import org.itsallcode.openfasttrace.api.core.SpecificationItem.Builder;
 import org.itsallcode.openfasttrace.api.core.SpecificationItemId;
@@ -21,8 +21,6 @@ import org.itsallcode.openfasttrace.api.importer.SpecificationListBuilder;
 import org.itsallcode.openfasttrace.api.importer.input.InputFile;
 import org.itsallcode.openfasttrace.testutil.importer.input.StreamInput;
 import org.junit.jupiter.api.Test;
-
-import com.github.hamstercommunity.matcher.auto.AutoMatcher;
 
 // [utest->dsn~import.full-coverage-tag~1]
 class TestTagImporter
@@ -304,7 +302,7 @@ class TestTagImporter
     }
 
     private static SpecificationItem itemWithReadableName(final String artifactType, final int lineNumber,
-            final SpecificationItemId coveredId, List<String> neededArtifactTypes)
+            final SpecificationItemId coveredId, final List<String> neededArtifactTypes)
     {
         final SpecificationItemId generatedId = SpecificationItemId.createId(artifactType,
                 coveredId.getName(), 0);
@@ -317,7 +315,7 @@ class TestTagImporter
     }
 
     private static SpecificationItem item(final String artifactType, final int lineNumber,
-            final int counter, final SpecificationItemId coveredId, List<String> neededArtifactTypes)
+            final int counter, final SpecificationItemId coveredId, final List<String> neededArtifactTypes)
     {
         final SpecificationItemId generatedId = SpecificationItemId.createId(artifactType,
                 generateName(coveredId, lineNumber, counter), 0);

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -8,7 +8,7 @@
     <description>Free requirement tracking suite</description>
     <url>https://github.com/itsallcode/openfasttrace</url>
     <properties>
-        <revision>3.7.1</revision>
+        <revision>3.7.2</revision>
         <java.version>11</java.version>
         <junit.version>5.10.1</junit.version>
         <maven.surefire.version>3.2.5</maven.surefire.version>
@@ -202,7 +202,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-junit-jupiter</artifactId>
-                <version>5.9.0</version>
+                <version>5.10.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
@@ -214,7 +214,7 @@
             <dependency>
                 <groupId>org.itsallcode</groupId>
                 <artifactId>hamcrest-auto-matcher</artifactId>
-                <version>0.5.0</version>
+                <version>0.6.0</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/product/src/test/java/org/itsallcode/openfasttrace/exporter/specobject/TestSpecobjectExportImport.java
+++ b/product/src/test/java/org/itsallcode/openfasttrace/exporter/specobject/TestSpecobjectExportImport.java
@@ -3,25 +3,22 @@ package org.itsallcode.openfasttrace.exporter.specobject;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.List;
 
 import javax.xml.stream.*;
+import javax.xml.stream.Location;
 
+import org.itsallcode.matcher.auto.AutoMatcher;
 import org.itsallcode.openfasttrace.api.core.*;
-import org.itsallcode.openfasttrace.api.core.Location;
 import org.itsallcode.openfasttrace.api.importer.SpecificationListBuilder;
 import org.itsallcode.openfasttrace.api.importer.input.InputFile;
 import org.itsallcode.openfasttrace.importer.specobject.SpecobjectImporterFactory;
 import org.itsallcode.openfasttrace.testutil.importer.input.StreamInput;
 import org.itsallcode.openfasttrace.testutil.xml.IndentingXMLStreamWriter;
 import org.junit.jupiter.api.Test;
-
-import com.github.hamstercommunity.matcher.auto.AutoMatcher;
 
 class TestSpecobjectExportImport
 {

--- a/product/src/test/java/org/itsallcode/openfasttrace/exporter/specobject/TestSpecobjectExportImport.java
+++ b/product/src/test/java/org/itsallcode/openfasttrace/exporter/specobject/TestSpecobjectExportImport.java
@@ -9,7 +9,6 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import javax.xml.stream.*;
-import javax.xml.stream.Location;
 
 import org.itsallcode.matcher.auto.AutoMatcher;
 import org.itsallcode.openfasttrace.api.core.*;
@@ -29,7 +28,7 @@ class TestSpecobjectExportImport
         final SpecificationItem item = SpecificationItem.builder() //
                 .id(SpecificationItemId.createId("foo", "bar", 1)) //
                 .description("the description") //
-                .location(Location.create("dummy.xml", 4)) //
+                .location(location(4)) //
                 .build();
         assertExportAndImport(item);
     }
@@ -48,7 +47,7 @@ class TestSpecobjectExportImport
                 .addDependOnId("req", "depend-on", 1) //
                 .addNeedsArtifactType("impl") //
                 .addTag("the tag") //
-                .location(Location.create("dummy.xml", 4)) //
+                .location(location(4)) //
                 .build();
         assertExportAndImport(item);
     }
@@ -62,7 +61,7 @@ class TestSpecobjectExportImport
                 .description("the description") //
                 .rationale("the rationale") //
                 .comment("the comment") //
-                .location(Location.create("dummy.xml", 4)) //
+                .location(location(4)) //
                 .build();
         final SpecificationItem itemB = SpecificationItem.builder() //
                 .id(SpecificationItemId.createId("baz", "zoo", 2)) //
@@ -70,9 +69,14 @@ class TestSpecobjectExportImport
                 .description("another\ndescription") //
                 .rationale("another\nrationale") //
                 .comment("another\ncomment") //
-                .location(Location.create("dummy.xml", 5)) //
+                .location(location(5)) //
                 .build();
         assertExportAndImport(itemA, itemB);
+    }
+
+    private org.itsallcode.openfasttrace.api.core.Location location(final int line)
+    {
+        return org.itsallcode.openfasttrace.api.core.Location.create("dummy.xml", line);
     }
 
     private void assertExportAndImport(final SpecificationItem... items)

--- a/product/src/test/java/org/itsallcode/openfasttrace/importer/specobject/TestSpecobjectImportExport.java
+++ b/product/src/test/java/org/itsallcode/openfasttrace/importer/specobject/TestSpecobjectImportExport.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import java.nio.file.Paths;
 import java.util.List;
 
+import org.itsallcode.matcher.auto.AutoMatcher;
 import org.itsallcode.openfasttrace.api.core.*;
 import org.itsallcode.openfasttrace.api.importer.Importer;
 import org.itsallcode.openfasttrace.api.importer.SpecificationListBuilder;
@@ -17,8 +18,6 @@ import org.itsallcode.openfasttrace.core.Linker;
 import org.itsallcode.openfasttrace.core.Tracer;
 import org.itsallcode.openfasttrace.testutil.importer.input.StreamInput;
 import org.junit.jupiter.api.Test;
-
-import com.github.hamstercommunity.matcher.auto.AutoMatcher;
 
 class TestSpecobjectImportExport
 {


### PR DESCRIPTION
Closes #364
This PR addresses issue 364: https://github.com/itsallcode/openfasttrace/issues/364

I noticed that "Tags" lists behave the same way, so I updated them as well.