### PR TITLE
Add support for reading Tags from Gherkin feature files

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,10 @@ OpenFastTrace at it's core is a Java Archive (short "[JAR](https://docs.oracle.c
 
 ### Getting Pre-Built Packages
 
-Pre-Built JAR files (called `openfasttrace-4.0.2.jar`) are available from the following places:
+Pre-Built JAR files (called `openfasttrace-4.1.0.jar`) are available from the following places:
 
-* [Maven Central](https://repo1.maven.org/maven2/org/itsallcode/openfasttrace/openfasttrace/4.0.2/openfasttrace-4.0.2.jar)
-* [GitHub](https://github.com/itsallcode/openfasttrace/releases/download/4.0.2/openfasttrace-4.0.2.jar)
+* [Maven Central](https://repo1.maven.org/maven2/org/itsallcode/openfasttrace/openfasttrace/4.1.0/openfasttrace-4.1.0.jar)
+* [GitHub](https://github.com/itsallcode/openfasttrace/releases/download/4.1.0/openfasttrace-4.1.0.jar)
  
 Check our [developer guide](doc/developer_guide.md#getting-the-openfasttrace-library) to learn how to use the OFT JAR as dependency in your own code with popular build tools.
 
@@ -97,7 +97,7 @@ If you just want to run OFT:
 The most basic variant to run OpenFastTrace is directly from the JAR file via the command line:
 
 ```bash
-java -jar product/target/openfasttrace-4.0.2.jar trace /path/to/directory/being/traced
+java -jar product/target/openfasttrace-4.1.0.jar trace /path/to/directory/being/traced
 ```
 
 If you want to run OFT automatically as part of a continuous build, we recommend using our plugins for [Gradle](https://github.com/itsallcode/openfasttrace-gradle) and [Maven](https://github.com/itsallcode/openfasttrace-maven-plugin).

--- a/doc/changes/changes.md
+++ b/doc/changes/changes.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [4.1.0](changes_4.1.0.md)
 * [4.0.2](changes_4.0.2.md)
 * [4.0.1](changes_4.0.1.md)
 * [4.0.0](changes_4.0.0.md)

--- a/doc/changes/changes_4.1.0.md
+++ b/doc/changes/changes_4.1.0.md
@@ -1,0 +1,15 @@
+# OpenFastTrace 4.1.0, released 2024-08-??
+
+Code name: ???
+
+## Summary
+
+This release adds support for using [Gherkin](https://cucumber.io/docs/gherkin/) `feature` files with OFT.
+
+## Features
+
+* #425: Add support for reading Tags from Gherkin feature files
+
+## Bugfixes
+
+## Refactoring

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -15,7 +15,7 @@ To use OpenFastTrace as a dependency in your [Maven](https://maven.apache.org) p
     <dependency>
         <groupId>org.itsallcode.openfasttrace</groupId>
         <artifactId>openfasttrace</artifactId>
-        <version>3.8.0</version>
+        <version>4.1.0</version>
         <scope>compile</scope>
     </dependency>
 </dependencies>
@@ -27,7 +27,7 @@ To use OpenFastTrace as a dependency in your [Gradle](https://gradle.org/) proje
 
 ```groovy
 dependencies {
-    compile "org.itsallcode.openfasttrace:openfasttrace:3.8.0"
+    compile "org.itsallcode.openfasttrace:openfasttrace:4.1.0"
 }
 ```
 
@@ -36,13 +36,13 @@ dependencies {
 The list below shows all build time dependencies in alphabetical order. Note that except the Maven build tool all required modules are downloaded automatically by Maven.
 
 | Dependency                                                                         | Purpose                                                | License                       |
-|------------------------------------------------------------------------------------|--------------------------------------------------------|-------------------------------|
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------ | ----------------------------- |
 | [Apache Maven](https://maven.apache.org/)                                          | Build tool                                             | Apache License 2.0            |
 | [Equals Verifier](https://github.com/jqno/equalsverifier)                          | Automatic contract checker for `equals()` and `hash()` | Apache License 2.0            |
 | [Hamcrest Auto Matcher](https://github.com/itsallcode/hamcrest-auto-matcher)       | Speed-up for building Hamcrest matchers                | GNU General Public License V3 |
 | [JUnit](https://junit.org/junit5)                                                  | Unit testing framework                                 | Eclipse Public License 1.0    |
 | [Mockito](https://github.com/mockito/mockito)                                      | Mocking framework                                      | MIT License                   |
-| [JUnit5 System Extensions](https://github.com/itsallcode/junit5-system-extensions) | JUnit extension for testing `System.x` calls    | Eclipse Public License 2.0     |
+| [JUnit5 System Extensions](https://github.com/itsallcode/junit5-system-extensions) | JUnit extension for testing `System.x` calls           | Eclipse Public License 2.0    |
 
 ## Preparations
 

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -670,6 +670,10 @@ recognized file types:
 
 Note that XML is at the moment not yet supported by the Tag Importer, because it would collide with the SpecObj Importer. Once import fallback is implemented, XML will be supported too.
 
+**Test Specification languages**
+
+* [Gherkin](https://cucumber.io/docs/gherkin/) (`.feature`)
+ 
 #### Markdown
 
 The main importer of OFT accepts markdown files with the extensions `.md` and `.markdown`.
@@ -1075,11 +1079,11 @@ The OFT command line interface returns the following exit codes:
 
 The following editors and integrated development environments are well suited for authoring OFT documents. The list is not exhaustive, any editor with Markdown capabilities can be used.
 
-| Editor / IDE                                           | Syntax highl. | Preview | Outline | HTML export |
-|--------------------------------------------------------|---------------|---------|---------|-------------|
-| [Gedit](https://wiki.gnome.org/Apps/Gedit)             | y             |         |         |             |
-| [Eclipse](https://eclipse.org) with WikiText plug-in   | y             | y       | y       | y           |
-| [Eclipse](https://eclipse.org) with GMF plug-in        |               | y       |         |             |
-| [IntelliJ](https://www.jetbrains.com/idea/)            | y             | y       | y       | y           |
-| [Vim](https://www.vim.org/)                            | y             |         |         |             |
-| [Visual Studio Code](https://code.visualstudio.com/)   | y             | y       | y       |             |
+| Editor / IDE                                         | Syntax highl. | Preview | Outline | HTML export |
+| ---------------------------------------------------- | ------------- | ------- | ------- | ----------- |
+| [Gedit](https://wiki.gnome.org/Apps/Gedit)           | y             |         |         |             |
+| [Eclipse](https://eclipse.org) with WikiText plug-in | y             | y       | y       | y           |
+| [Eclipse](https://eclipse.org) with GMF plug-in      |               | y       |         |             |
+| [IntelliJ](https://www.jetbrains.com/idea/)          | y             | y       | y       | y           |
+| [Vim](https://www.vim.org/)                          | y             |         |         |             |
+| [Visual Studio Code](https://code.visualstudio.com/) | y             | y       | y       |             |

--- a/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/TagImporterFactory.java
+++ b/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/TagImporterFactory.java
@@ -21,6 +21,7 @@ public class TagImporterFactory extends ImporterFactory
             "c", "C", "cc", "cpp", "c++", "h", "H", "h++", "hh", "hpp", // C/C++
             "c#", "cs", // C#
             "cfg", "conf", "ini", // configuration files
+            "feature", // Gherkin feature files
             "go", // Go
             "groovy", // Groovy
             "json", "htm", "html", "xhtml", "yaml", "yml", // markup languages

--- a/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporterFactory.java
+++ b/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporterFactory.java
@@ -26,7 +26,7 @@ class TestTagImporterFactory extends ImporterFactoryTestBase<TagImporterFactory>
     {
         return asList("file.java", "FILE.java", "file.md.java", "foo.bash", "foo.bar.bash",
                 "foo.bat", "foo.java", "foo.c", "foo.C", "foo.c++", "foo.c#", "foo.cc", "foo.cfg",
-                "foo.conf", "foo.cpp", "foo.cs", "foo.groovy", "foo.h", "foo.H", "foo.hh", "foo.h++",
+                "foo.conf", "foo.cpp", "foo.cs", "foo.feature", "foo.groovy", "foo.h", "foo.H", "foo.hh", "foo.h++",
                 "foo.htm", "foo.html", "foo.ini", "foo.js", "foo.ts", "foo.json", "foo.lua", "foo.m",
                 "foo.mm", "foo.php", "foo.pl", "foo.pls", "foo.pm", "foo.py", "foo.sql", "foo.r",
                 "foo.rs", "foo.sh", "foo.yaml", "foo.yml", "foo.xhtml", "foo.zsh", "foo.clj", "foo.kt", "foo.scala",

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1,4 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.itsallcode.openfasttrace</groupId>
     <artifactId>openfasttrace-parent</artifactId>
@@ -8,7 +10,7 @@
     <description>Free requirement tracking suite</description>
     <url>https://github.com/itsallcode/openfasttrace</url>
     <properties>
-        <revision>4.0.2</revision>
+        <revision>4.1.0</revision>
         <java.version>17</java.version>
         <junit.version>5.11.0-M2</junit.version>
         <maven.surefire.version>3.2.5</maven.surefire.version>
@@ -16,7 +18,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <reproducible.build.timestamp>${git.commit.time}</reproducible.build.timestamp>
         <project.build.outputTimestamp>${reproducible.build.timestamp}</project.build.outputTimestamp>
-        <test.args><!-- Empty default value for Java version < 18 --></test.args>
+        <test.args><!-- Empty default value for Java version < 18 -->
+        </test.args>
     </properties>
     <licenses>
         <license>
@@ -270,7 +273,8 @@
             <activation>
                 <jdk>21</jdk>
                 <property>
-                    <!-- Prevent activating this profile when running without specifying -Djava.version.
+                    <!-- Prevent activating this profile when running without specifying
+                    -Djava.version.
                          Tests with JDK 11 fail because it expecteds a class name as value for for
                          system property "java.security.manager" -->
                     <name>java.version</name>
@@ -280,8 +284,10 @@
             <properties>
                 <!-- java.security.manager is required to fix failing tests in TestCliStarter:
                     UnsupportedOperation The Security Manager is deprecated and will be removed in a future release -->
-                <!-- EnableDynamicAgentLoading suppresses a warning caused by Mockito dynamically loading a Java agent:
-                    WARNING: A Java agent has been loaded dynamically (~/.m2/repository/net/bytebuddy/byte-buddy-agent/1.14.11/byte-buddy-agent-1.14.11.jar)
+                <!-- EnableDynamicAgentLoading suppresses a warning caused by Mockito dynamically
+                loading a Java agent:
+                    WARNING: A Java agent has been loaded dynamically
+                (~/.m2/repository/net/bytebuddy/byte-buddy-agent/1.14.11/byte-buddy-agent-1.14.11.jar)
                     Dynamic loading of agents will be disallowed by default in a future release -->
                 <test.args>-Djava.security.manager=allow -XX:+EnableDynamicAgentLoading</test.args>
             </properties>
@@ -368,7 +374,8 @@
                 </executions>
                 <configuration>
                     <charset>UTF-8</charset>
-                    <doclint><!-- Intentionally empty --></doclint>
+                    <doclint><!-- Intentionally empty -->
+                    </doclint>
                     <serialwarn>true</serialwarn>
                     <failOnError>true</failOnError>
                     <failOnWarnings>true</failOnWarnings>
@@ -419,13 +426,12 @@
                 <version>${maven.surefire.version}</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <java.util.logging.config.file>${basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <java.util.logging.config.file>
+                            ${basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
                     </systemPropertyVariables>
                     <useModulePath>true</useModulePath>
                     <argLine>
-                        <!-- Required for Java >= 18 -->
-                        ${test.args}
-                    </argLine>
+                        <!-- Required for Java >= 18 --> ${test.args} </argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -434,14 +440,13 @@
                 <version>${maven.surefire.version}</version>
                 <configuration>
                     <systemPropertyVariables>
-                        <java.util.logging.config.file>${basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+                        <java.util.logging.config.file>
+                            ${basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
                         <test.coverage>true</test.coverage>
                     </systemPropertyVariables>
                     <useModulePath>true</useModulePath>
                     <argLine>
-                        <!-- Required for Java >= 18 -->
-                        ${test.args}
-                    </argLine>
+                        <!-- Required for Java >= 18 --> ${test.args} </argLine>
                 </configuration>
                 <executions>
                     <execution>
@@ -502,7 +507,7 @@
                     <useResultFile>false</useResultFile>
                 </configuration>
             </plugin>
-             <plugin>
+            <plugin>
                 <groupId>org.sonatype.ossindex.maven</groupId>
                 <artifactId>ossindex-maven-plugin</artifactId>
                 <version>3.2.0</version>
@@ -524,7 +529,9 @@
                     <execution>
                         <id>verify-reproducible-build</id>
                         <phase>verify</phase>
-                        <goals><goal>check-buildplan</goal></goals>
+                        <goals>
+                            <goal>check-buildplan</goal>
+                        </goals>
                     </execution>
                 </executions>
                 <configuration>
@@ -609,7 +616,8 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.2</version>
                 </plugin>
-                <!--This plugin's configuration is used to store Eclipse 
+                <!--This
+                plugin's configuration is used to store Eclipse 
                     m2e settings only. It has no influence on the Maven build itself. -->
                 <plugin>
                     <groupId>org.eclipse.m2e</groupId>
@@ -623,9 +631,13 @@
                                         <groupId>org.apache.maven.plugins</groupId>
                                         <artifactId>maven-toolchains-plugin</artifactId>
                                         <versionRange>*</versionRange>
-                                        <goals><goal>toolchain</goal></goals>
+                                        <goals>
+                                            <goal>toolchain</goal>
+                                        </goals>
                                     </pluginExecutionFilter>
-                                    <action><ignore/></action>
+                                    <action>
+                                        <ignore />
+                                    </action>
                                 </pluginExecution>
                             </pluginExecutions>
                         </lifecycleMappingMetadata>


### PR DESCRIPTION
Added "feature" to the list of supported file extensions so that
the standard Tag importer can now extract Tags from comments in
"feature" files as used by Gherkin.

This addresses #425

Closes #425 