### PR TITLE
#440: Support TOML files in tag importer

### DIFF
--- a/doc/changes/changes_4.2.0.md
+++ b/doc/changes/changes_4.2.0.md
@@ -15,5 +15,6 @@ We also added a whole section about understanding and fixing broken links betwee
 
 ## Documentation
 
-* #427: Removed old `CHANGELOG.md` file and merged missing parts into release history
+* #427: Removed old `CHANGELOG.md` file and merged missing parts into release history.
 * #431: Documented "unwanted coverage" in user guide.
+* #440: Added Tag importer support for TOML files.

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -722,7 +722,6 @@ recognized file types:
 * Java (`.java`)
 * JavaScript (`.js`)
 * TypeScript (`.ts`)
-* JSON (`.json`)
 * Lua (`.lua`)
 * Objective C (`.m`, `.mm`)
 * Perl (`.pl`, `.pm`)
@@ -734,6 +733,11 @@ recognized file types:
 * Swift (`.swift`)
 * Terraform (`.tf`, `.tfvars`)
 * Windows batch files (`.bat`)
+
+**Configuration and Serialization Formats** 
+
+* JSON (`.json`)
+* TOML (`.toml`)
 
 **Markup languages**
 

--- a/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/TagImporterFactory.java
+++ b/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/TagImporterFactory.java
@@ -38,6 +38,7 @@ public class TagImporterFactory extends ImporterFactory
             "rs", // Rust
             "sh", "bash", "zsh", // Shell programming
             "swift", // Swift
+            "toml", // Tom's Obvious Minimal Language : a config file format
             "tf", "tfvars", // Terraform
             "sql", "pls" // Database related
     );

--- a/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporterFactory.java
+++ b/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporterFactory.java
@@ -30,7 +30,7 @@ class TestTagImporterFactory extends ImporterFactoryTestBase<TagImporterFactory>
                 "foo.htm", "foo.html", "foo.ini", "foo.js", "foo.ts", "foo.json", "foo.lua", "foo.m",
                 "foo.mm", "foo.php", "foo.pl", "foo.pls", "foo.pm", "foo.py", "foo.sql", "foo.r",
                 "foo.rs", "foo.sh", "foo.yaml", "foo.yml", "foo.xhtml", "foo.zsh", "foo.clj", "foo.kt", "foo.scala",
-                "foo.pu", "foo.puml", "foo.plantuml", "foo.go", "foo.robot", "foo.tf", "foo.tfvars");
+                "foo.pu", "foo.puml", "foo.plantuml", "foo.go", "foo.robot", "foo.tf", "foo.tfvars", "foo.toml");
     }
 
     @Override


### PR DESCRIPTION
Add support for ".toml" files in the tag importer factory.

Closes #440.