### PR TITLE
add modern javascript extension support

### DIFF
--- a/doc/changes/changes_4.2.0.md
+++ b/doc/changes/changes_4.2.0.md
@@ -18,3 +18,4 @@ We also added a whole section about understanding and fixing broken links betwee
 * #427: Removed old `CHANGELOG.md` file and merged missing parts into release history.
 * #431: Documented "unwanted coverage" in user guide.
 * #440: Added Tag importer support for TOML files.
+* #442: Added support for javascript file extensions `.cjs`, `.mjs` and `.ejs`

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -720,7 +720,7 @@ recognized file types:
 * [Go](https://golang.org/) (`.go`)
 * Groovy (`.groovy`)
 * Java (`.java`)
-* JavaScript (`.js`)
+* JavaScript (`.js`, `.ejs`, `.cjs`, `.mjs`)
 * TypeScript (`.ts`)
 * Lua (`.lua`)
 * Objective C (`.m`, `.mm`)

--- a/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/TagImporterFactory.java
+++ b/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/TagImporterFactory.java
@@ -25,7 +25,7 @@ public class TagImporterFactory extends ImporterFactory
             "json", "htm", "html", "xhtml", "yaml", "yml", // markup languages
             "java", // Java
             "clj", "kt", "scala", // JVM languages
-            "js", // JavaScript
+            "js", "mjs", "cjs", "ejs", // JavaScript
             "ts", // TypeScript
             "lua", // Lua
             "m", "mm", // Objective C

--- a/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporterFactory.java
+++ b/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporterFactory.java
@@ -27,8 +27,8 @@ class TestTagImporterFactory extends ImporterFactoryTestBase<TagImporterFactory>
         return asList("file.java", "FILE.java", "file.md.java", "foo.bash", "foo.bar.bash",
                 "foo.bat", "foo.java", "foo.c", "foo.C", "foo.c++", "foo.c#", "foo.cc", "foo.cfg",
                 "foo.conf", "foo.cpp", "foo.cs", "foo.feature", "foo.groovy", "foo.h", "foo.H", "foo.hh", "foo.h++",
-                "foo.htm", "foo.html", "foo.ini", "foo.js", "foo.ts", "foo.json", "foo.lua", "foo.m",
-                "foo.mm", "foo.php", "foo.pl", "foo.pls", "foo.pm", "foo.py", "foo.sql", "foo.r",
+                "foo.htm", "foo.html", "foo.ini", "foo.js", "foo.mjs", "foo.cjs", "foo.ejs", "foo.ts", "foo.json", 
+                "foo.lua", "foo.m", "foo.mm", "foo.php", "foo.pl", "foo.pls", "foo.pm", "foo.py", "foo.sql", "foo.r",
                 "foo.rs", "foo.sh", "foo.yaml", "foo.yml", "foo.xhtml", "foo.zsh", "foo.clj", "foo.kt", "foo.scala",
                 "foo.pu", "foo.puml", "foo.plantuml", "foo.go", "foo.robot", "foo.tf", "foo.tfvars", "foo.toml");
     }


### PR DESCRIPTION
In addition to `.js`, modern javascript may use `.mjs`, `.cjs`, and `.ejs`. This request adds those extensions to `TagImporterFactory.java` and `TestTagImporterFactory.java`

[Node Doc](https://nodejs.org/docs/latest-v20.x/api/modules.html#enabling)

