### PR TITLE
Added support for requirement refinement

### DIFF
--- a/api/src/main/java/org/itsallcode/openfasttrace/api/core/LinkedSpecificationItem.java
+++ b/api/src/main/java/org/itsallcode/openfasttrace/api/core/LinkedSpecificationItem.java
@@ -17,6 +17,8 @@ public class LinkedSpecificationItem
     private final Set<String> coveredArtifactTypes = new HashSet<>();
     private final Set<String> coveredArtifactTypesFromApprovedItems = new HashSet<>();
     private final Set<String> overCoveredArtifactTypes = new HashSet<>();
+    private boolean isRefined = false;
+    private boolean isRefinedApproved = false;
 
     /**
      * Create a new instance of class {@link LinkedSpecificationItem}.
@@ -142,6 +144,10 @@ public class LinkedSpecificationItem
             cacheApprovedCoveredArtifactType(item);
             coveredArtifactTypes.add(item.getArtifactType());
             addMyItemIdToCoveringItem(item);
+            if (item.getArtifactType() != null && item.getArtifactType().equals(this.getArtifactType()))
+            {
+                isRefined = true;
+            }
             break;
         case COVERED_UNWANTED:
             cacheOverCoveredArtifactType(item);
@@ -171,6 +177,10 @@ public class LinkedSpecificationItem
         if (coveringItem.isApproved())
         {
             coveredArtifactTypesFromApprovedItems.add(coveringItem.getArtifactType());
+            if (coveringItem.getArtifactType() != null && coveringItem.getArtifactType().equals(this.getArtifactType()))
+            {
+                isRefinedApproved = true;
+            }
         }
     }
 
@@ -298,6 +308,22 @@ public class LinkedSpecificationItem
         final List<String> uncovered = new ArrayList<>(getNeedsArtifactTypes());
         uncovered.removeAll(getCoveredApprovedArtifactTypes());
         return uncovered;
+    }
+
+    /**
+     * @return true if this item is covered by an item of the same artifactType.
+     */
+    public boolean isRefined()
+    {
+        return isRefined;
+    }
+
+    /**
+     * @return if this item is approved and is covered by an item of the same artifactType that is also approved.
+     */
+    public boolean isRefinedApproved()
+    {
+        return isRefinedApproved;
     }
 
     /**
@@ -447,12 +473,12 @@ public class LinkedSpecificationItem
 
     private boolean areAllArtifactTypesCovered()
     {
-        return this.getCoveredArtifactTypes().containsAll(this.getNeedsArtifactTypes());
+        return isRefined || this.getCoveredArtifactTypes().containsAll(this.getNeedsArtifactTypes());
     }
 
     private boolean areAllCoveredArtifactTypesApproved()
     {
-        return this.getCoveredApprovedArtifactTypes().containsAll(this.getNeedsArtifactTypes());
+        return isRefinedApproved || this.getCoveredApprovedArtifactTypes().containsAll(this.getNeedsArtifactTypes());
     }
 
     private boolean isApproved()

--- a/api/src/main/java/org/itsallcode/openfasttrace/api/core/LinkedSpecificationItem.java
+++ b/api/src/main/java/org/itsallcode/openfasttrace/api/core/LinkedSpecificationItem.java
@@ -311,6 +311,8 @@ public class LinkedSpecificationItem
     }
 
     /**
+     * Check if this item is covered by an item of the same artifactType.
+     *
      * @return true if this item is covered by an item of the same artifactType.
      */
     public boolean isRefined()
@@ -319,6 +321,8 @@ public class LinkedSpecificationItem
     }
 
     /**
+     * Check if this item is covered by an item of the same artifactType and both items are approved.
+     *
      * @return if this item is approved and is covered by an item of the same artifactType that is also approved.
      */
     public boolean isRefinedApproved()

--- a/core/src/main/java/org/itsallcode/openfasttrace/core/Linker.java
+++ b/core/src/main/java/org/itsallcode/openfasttrace/core/Linker.java
@@ -1,7 +1,6 @@
 package org.itsallcode.openfasttrace.core;
 
 import java.util.HashMap;
-
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -83,7 +82,8 @@ public class Linker
             final LinkedSpecificationItem covered)
     {
         final String coveringArtifactType = covering.getArtifactType();
-        if (covered.getItem().getNeedsArtifactTypes().contains(coveringArtifactType))
+        if (covered.getItem().getNeedsArtifactTypes().contains(coveringArtifactType) ||
+                covered.getArtifactType().equals(covering.getArtifactType()))
         {
             if (covered.hasDuplicates())
             {

--- a/core/src/test/java/org/itsallcode/openfasttrace/core/TestLinker.java
+++ b/core/src/test/java/org/itsallcode/openfasttrace/core/TestLinker.java
@@ -196,7 +196,7 @@ class TestLinker
         }
     }
 
-    public static void assertItemRefined( final LinkedSpecificationItem item, final boolean approved )
+    private static void assertItemRefined( final LinkedSpecificationItem item, final boolean approved )
     {
         if(approved) {
             assertThat( item.getId() + " is refined by approved item", item.isRefinedApproved(), is(true));

--- a/core/src/test/java/org/itsallcode/openfasttrace/core/TestLinker.java
+++ b/core/src/test/java/org/itsallcode/openfasttrace/core/TestLinker.java
@@ -1,19 +1,17 @@
 package org.itsallcode.openfasttrace.core;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.*;
 import static org.itsallcode.openfasttrace.api.core.LinkStatus.*;
 import static org.itsallcode.openfasttrace.api.core.SpecificationItemId.createId;
 import static org.itsallcode.openfasttrace.testutil.core.ItemBuilderFactory.item;
-import static org.itsallcode.openfasttrace.testutil.core.SampleArtifactTypes.IMPL;
-import static org.itsallcode.openfasttrace.testutil.core.SampleArtifactTypes.REQ;
-import static org.itsallcode.openfasttrace.testutil.core.SampleArtifactTypes.UTEST;
+import static org.itsallcode.openfasttrace.testutil.core.SampleArtifactTypes.*;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
+import org.itsallcode.openfasttrace.api.core.DeepCoverageStatus;
 import org.itsallcode.openfasttrace.api.core.LinkStatus;
 import org.itsallcode.openfasttrace.api.core.LinkedSpecificationItem;
 import org.itsallcode.openfasttrace.api.core.SpecificationItem;
@@ -198,6 +196,16 @@ class TestLinker
         }
     }
 
+    public static void assertItemRefined( final LinkedSpecificationItem item, final boolean approved )
+    {
+        if(approved) {
+            assertThat( item.getId() + " is refined by approved item", item.isRefinedApproved(), is(true));
+        } else {
+            assertThat( item.getId() + " is refined by an item", item.isRefined(), is(true));
+        }
+    }
+
+
     private String createDebugInfoFromExpectedStatuses(
             final Map<LinkStatus, Integer> expectedStatuses)
     {
@@ -295,7 +303,7 @@ class TestLinker
                 .addCoveredId(REQ, "to-be-covered", 42) //
                 .build();
         final SpecificationItem unwanted = item() //
-                .id(REQ, "unwanted", 1) //
+                .id(ITEST, "unwanted", 1) //
                 .addCoveredId(REQ, "to-be-covered", 42) //
                 .build();
         final List<LinkedSpecificationItem> linkedItems = linkItems(covering, covered, unwanted);
@@ -312,6 +320,37 @@ class TestLinker
         }
         else
         {
+            fail("Covered item " + covered.getId() + " not found in linked items");
+        }
+    }
+
+    @Test
+    void testRefiningItemCoverItem()
+    {
+        final SpecificationItem covered = item() //
+                .id(REQ, "to-be-covered", 42) //
+                .addNeedsArtifactType(IMPL) //
+                .addNeedsArtifactType(UTEST) //
+                .build();
+        final SpecificationItem coveringReq = item() //
+                .id(REQ, "covering", 1) //
+                .addCoveredId(REQ, "to-be-covered", 42) //
+                .build();
+        final SpecificationItem coveringImpl = item() //
+                .id(IMPL, "covering", 1) //
+                .addCoveredId(REQ, "to-be-covered", 42) //
+                .build();
+        final List<LinkedSpecificationItem> linkedItems = linkItems(coveringReq, covered, coveringImpl);
+        final Optional<LinkedSpecificationItem> linkedCovered = findLinkedItem(covered,linkedItems);
+        if (linkedCovered.isPresent())
+        {
+            assertItemRefined(linkedCovered.get(), false);
+            assertItemRefined(linkedCovered.get(), true);
+            assertThat(linkedCovered.get().isCoveredShallow(),is(true));
+            assertThat(linkedCovered.get().isCoveredShallowWithApprovedItems(),is(true));
+            assertThat(linkedCovered.get().getDeepCoverageStatus(),equalTo(DeepCoverageStatus.COVERED));
+            assertThat(linkedCovered.get().getDeepCoverageStatusOnlyAcceptApprovedItems(),equalTo(DeepCoverageStatus.COVERED));
+        } else {
             fail("Covered item " + covered.getId() + " not found in linked items");
         }
     }


### PR DESCRIPTION
`LinkedSpecificationItem` is covered when covered by at least one ` SpecificationItem`  of the same type.