### PR TITLE
Status rejected for Restructured and Markdown importer.

### DIFF
--- a/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MdPattern.java
+++ b/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MdPattern.java
@@ -48,7 +48,7 @@ enum MdPattern
             + "(?:\\W.*)?"),
     NOT_EMPTY("([^\n\r]+)"),
     RATIONALE("Rationale:\\s*"),
-    STATUS("Status:\\s*(approved|proposed|draft)\\s*"),
+    STATUS("Status:\\s*(approved|proposed|draft|rejected)\\s*"),
     TAGS_INT("Tags:(\\s*\\w+\\s*(?:,\\s*\\w+\\s*)*)"),
     TAGS("Tags:\\s*"),
     TAG_ENTRY(PatternConstants.UP_TO_3_WHITESPACES + PatternConstants.BULLETS

--- a/importer/restructuredtext/src/main/java/org/itsallcode/openfasttrace/importer/restructuredtext/RstPattern.java
+++ b/importer/restructuredtext/src/main/java/org/itsallcode/openfasttrace/importer/restructuredtext/RstPattern.java
@@ -46,7 +46,7 @@ enum RstPattern
             + "(?:\\W.*)?"),
     NOT_EMPTY("([^\n\r]+)"),
     RATIONALE("Rationale:\\s*"),
-    STATUS("Status:\\s*(approved|proposed|draft)\\s*"),
+    STATUS("Status:\\s*(approved|proposed|draft|rejected)\\s*"),
     TAGS_INT("Tags:(\\s*\\w+\\s*(?:,\\s*\\w+\\s*)*)"),
     TAGS("Tags:\\s*"),
     TAG_ENTRY(PatternConstants.UP_TO_3_WHITESPACES + PatternConstants.BULLETS


### PR DESCRIPTION
Both Restructured and Markdown importer at the moment do not support the ItemStatus rejected. This change extends the importer to also accept "rejected" as status.