### PR TITLE
Force English locale only for test runs

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -18,8 +18,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <reproducible.build.timestamp>${git.commit.time}</reproducible.build.timestamp>
         <project.build.outputTimestamp>${reproducible.build.timestamp}</project.build.outputTimestamp>
-        <test.args><!-- Empty default value for Java version < 18 -->
-        </test.args>
+        <test.args>-Duser.language=en</test.args>
     </properties>
     <licenses>
         <license>


### PR DESCRIPTION
When running XmlParser tests on a non English environment, the expected exception messages don't match:

```sh
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   XmlParserTest.testParsingInvalidXmlFormatFails:41 
     Expected: "Failed to parse file 'path': Content is not allowed in prolog."
     but: was "Failed to parse file 'path': Contenu non autorisé dans le prologue."
[INFO] 
[ERROR] Tests run: 4, Failures: 1, Errors: 0, Skipped: 0
```
For reproducibility purposes on all types of environment, we can simply force English locale for surefire tests execution in order to prevent false failures.