### PR TITLE
Add help option aliases

### DIFF
--- a/core/src/main/java/org/itsallcode/openfasttrace/core/cli/CliArguments.java
+++ b/core/src/main/java/org/itsallcode/openfasttrace/core/cli/CliArguments.java
@@ -11,6 +11,7 @@ import org.itsallcode.openfasttrace.api.core.Newline;
 import org.itsallcode.openfasttrace.api.report.ReportConstants;
 import org.itsallcode.openfasttrace.api.report.ReportVerbosity;
 import org.itsallcode.openfasttrace.core.cli.commands.ConvertCommand;
+import org.itsallcode.openfasttrace.core.cli.commands.HelpCommand;
 import org.itsallcode.openfasttrace.core.cli.commands.TraceCommand;
 import org.itsallcode.openfasttrace.core.cli.logging.LogLevel;
 import org.itsallcode.openfasttrace.core.exporter.ExporterConstants;
@@ -45,10 +46,11 @@ public class CliArguments
 
     // [impl->dsn~cli.plugins.log~1]
     private LogLevel logLevel;
+    private boolean helpRequested;
 
     /**
      * Create new {@link CliArguments}.
-     * 
+     *
      * @param directoryService
      *            the directory service used for evaluating command line
      *            arguments.
@@ -60,7 +62,7 @@ public class CliArguments
 
     /**
      * Get the output file path
-     * 
+     *
      * @return output file path
      */
     public Path getOutputPath()
@@ -74,7 +76,7 @@ public class CliArguments
 
     /**
      * Set the output file path
-     * 
+     *
      * @param outputFile
      *            output file path
      */
@@ -85,7 +87,7 @@ public class CliArguments
 
     /**
      * Set the output file path
-     * 
+     *
      * @param outputFile
      *            output file path
      */
@@ -101,6 +103,10 @@ public class CliArguments
      */
     public Optional<String> getCommand()
     {
+        if (this.helpRequested)
+        {
+            return Optional.of(HelpCommand.COMMAND_NAME);
+        }
         if (this.unnamedValues == null || this.unnamedValues.isEmpty())
         {
             return Optional.empty();
@@ -134,6 +140,26 @@ public class CliArguments
     public void setUnnamedValues(final List<String> unnamedValues)
     {
         this.unnamedValues = unnamedValues;
+    }
+
+    /**
+     * Request command line help.
+     * @param helpRequested
+     *            whether help was requested
+     */
+    public void setHelp(final boolean helpRequested)
+    {
+        this.helpRequested = helpRequested;
+    }
+
+    /**
+     * Request command line help.
+     * @param helpRequested
+     *            whether help was requested
+     */
+    public void setH(final boolean helpRequested)
+    {
+        setHelp(helpRequested);
     }
 
     /**

--- a/core/src/test/java/org/itsallcode/openfasttrace/core/cli/TestCliArguments.java
+++ b/core/src/test/java/org/itsallcode/openfasttrace/core/cli/TestCliArguments.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.*;
 
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Optional;
 
 import org.itsallcode.openfasttrace.api.ColorScheme;
 import org.itsallcode.openfasttrace.api.DetailsSectionDisplay;
@@ -13,6 +14,7 @@ import org.itsallcode.openfasttrace.api.core.Newline;
 import org.itsallcode.openfasttrace.api.report.ReportConstants;
 import org.itsallcode.openfasttrace.api.report.ReportVerbosity;
 import org.itsallcode.openfasttrace.core.cli.commands.ConvertCommand;
+import org.itsallcode.openfasttrace.core.cli.commands.HelpCommand;
 import org.itsallcode.openfasttrace.core.cli.commands.TraceCommand;
 import org.itsallcode.openfasttrace.core.exporter.ExporterConstants;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,6 +44,28 @@ class TestCliArguments
     {
         this.arguments.setUnnamedValues(emptyList());
         assertThat(this.arguments.getCommand().isPresent(), is(false));
+    }
+
+    @Test
+    void testSetHelpRequestsHelpCommand()
+    {
+        this.arguments.setHelp(true);
+        assertThat(this.arguments.getCommand(), equalTo(Optional.of(HelpCommand.COMMAND_NAME)));
+    }
+
+    @Test
+    void testSetHRequestsHelpCommand()
+    {
+        this.arguments.setH(true);
+        assertThat(this.arguments.getCommand(), equalTo(Optional.of(HelpCommand.COMMAND_NAME)));
+    }
+
+    @Test
+    void testHelpRequestOverridesUnnamedCommand()
+    {
+        this.arguments.setUnnamedValues(List.of(TraceCommand.COMMAND_NAME));
+        this.arguments.setHelp(true);
+        assertThat(this.arguments.getCommand(), equalTo(Optional.of(HelpCommand.COMMAND_NAME)));
     }
 
     @Test

--- a/doc/spec/design.md
+++ b/doc/spec/design.md
@@ -923,6 +923,8 @@ The CLI expects one of the following commands as first unnamed command line para
 
     command = "trace" / "convert" / "help"
 
+The CLI also accepts `-h` and `--help` as aliases for the `help` command.
+
 Covers:
 
 * `req~cli.tracing.command~1`

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -579,6 +579,9 @@ Where `command` is one of
 
 * `trace` - create a requirement trace document
 * `convert` - convert to a different requirements format
+* `help` - print the command line usage
+
+You can also print the command line usage with `-h` or `--help`.
 
 and `option` is one or more of the options listed below.
 

--- a/product/src/test/java/org/itsallcode/openfasttrace/cli/CliExitIT.java
+++ b/product/src/test/java/org/itsallcode/openfasttrace/cli/CliExitIT.java
@@ -44,8 +44,25 @@ class CliExitIT
     @Test
     void testRunWithHelpCommand()
     {
+        assertHelpOutputFor(List.of("help"));
+    }
+
+    @Test
+    void testRunWithLongHelpOption()
+    {
+        assertHelpOutputFor(List.of("--help"));
+    }
+
+    @Test
+    void testRunWithShortHelpOption()
+    {
+        assertHelpOutputFor(List.of("-h"));
+    }
+
+    private void assertHelpOutputFor(final List<String> arguments)
+    {
         jarLauncher()
-                .args(List.of("help"))
+                .args(arguments)
                 .expectedExitCode(ExitStatus.OK.getCode())
                 .expectStdOut(startsWith("""
                         OpenFastTrace


### PR DESCRIPTION
## Summary
- map `-h` and `--help` to the existing `help` command
- add unit coverage for the Picocli setters and CLI integration coverage for both aliases
- document the aliases in the user guide and design spec

## Validation
- `mvn -T1C package -DskipTests -Dmaven.javadoc.skip=true`
- `mvn -pl core -am -Dtest=TestCliArguments -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -pl product -am -Dtest=CliExitIT -Dsurefire.failIfNoSpecifiedTests=false test`
- `git diff --check`

## AI assistance
AI assistance was used to draft and verify this small CLI change. I reviewed the diff and test output before submitting.

Fixes #503