### PR TITLE
Add separate build job for ossindex

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,9 +45,6 @@ jobs:
           distribution: "temurin"
           java-version: ${{ matrix.java }}
           cache: "maven"
-          server-id: ossindex
-          server-username: OSSINDEX_USERNAME
-          server-password: OSSINDEX_TOKEN
 
       - name: Cache SonarQube packages
         if: ${{ env.DEFAULT_OS == matrix.os && env.DEFAULT_JAVA == matrix.java }}
@@ -60,10 +57,8 @@ jobs:
       - name: Build with Java ${{ matrix.java }}
         run: |
           mvn --batch-mode -T 1C clean org.jacoco:jacoco-maven-plugin:prepare-agent install \
+              -Dossindex.skip=true \
               -Djava.version=${{ matrix.java }}
-        env:
-          OSSINDEX_USERNAME: ${{ secrets.OSSINDEX_USERNAME }}
-          OSSINDEX_TOKEN: ${{ secrets.OSSINDEX_TOKEN }}
 
       - name: Sonar analysis
         if: ${{ env.DEFAULT_OS == matrix.os && env.DEFAULT_JAVA == matrix.java && env.SONAR_TOKEN != null }}
@@ -79,6 +74,7 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
         run: |
           mvn --batch-mode -T 1C clean verify artifact:compare -DskipTests \
+              -Dossindex.skip=true \
               -Djava.version=${{ matrix.java }}
 
       - name: Archive oft binary
@@ -107,8 +103,37 @@ jobs:
         if: ${{ env.DEFAULT_OS == matrix.os && env.DEFAULT_JAVA == matrix.java }}
         run: .github/workflows/run_shellcheck.sh
 
-  build:
-    needs: matrix-build
+  ossindex:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v6
+      with:
+        persist-credentials: false
+    - uses: actions/setup-java@v5
+      with:
+        cache: maven
+        distribution: temurin
+        java-version: 17
+        server-id: ossindex
+        server-username: OSSINDEX_USERNAME
+        server-password: OSSINDEX_TOKEN
+    - name: Ossindex
+      run: |
+        mvn -T 1C --errors --batch-mode test-compile \
+            org.sonatype.ossindex.maven:ossindex-maven-plugin:audit \
+            org.sonatype.ossindex.maven:ossindex-maven-plugin:audit-aggregate
+      env:
+        OSSINDEX_USERNAME: ${{ secrets.OSSINDEX_USERNAME }}
+        OSSINDEX_TOKEN: ${{ secrets.OSSINDEX_TOKEN }}
+
+  build:
+    permissions:
+      contents: read
+    needs:
+    - matrix-build
+    - ossindex
+    runs-on: ubuntu-slim
     steps:
       - run: echo "Build successful"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
       - name: Build
-        run: mvn --batch-mode -T 1C clean install
+        run: mvn --batch-mode -T 1C clean install -Dossindex.skip=true
 
       - name: List secret GPG keys
         run: gpg --list-secret-keys

--- a/doc/developer_guide.md
+++ b/doc/developer_guide.md
@@ -82,6 +82,15 @@ OFT uses Maven Toolchains to configure the correct JDK version (see the [documen
             <jdkHome>/usr/lib/jvm/java-21-openjdk-amd64/</jdkHome>
         </configuration>
     </toolchain>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>25</version>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/java-25-openjdk-amd64/</jdkHome>
+        </configuration>
+    </toolchain>
 </toolchains>
 ```
 
@@ -134,6 +143,37 @@ Specify test class via system property `it.test` and module via command line opt
 ```sh
 mvn -Dit.test=CliStarterIT failsafe:integration-test -projects product
 ```
+
+### Check for Dependency Updates
+
+```sh
+mvn versions:display-dependency-updates versions:display-plugin-updates
+```
+
+### Check for Vulnerabilities in Dependencies
+
+Configure Ossindex credentials in `~/.m2/settings.xml`:
+
+```xml
+
+<settings>
+    <servers>
+        <server>
+            <id>ossindex</id>
+            <username>email@example.com</username>
+            <password>token</password>
+        </server>
+    </servers>
+</settings>
+```
+
+Then run
+
+```sh
+mvn -T 1C test-compile org.sonatype.ossindex.maven:ossindex-maven-plugin:audit org.sonatype.ossindex.maven:ossindex-maven-plugin:audit-aggregate
+```
+
+Ossindex also runs during `mvn verify`. Add `-Dossindex.skip=true` to skip it.
 
 ### Run Requirements Tracing
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -20,6 +20,7 @@
         <reproducible.build.timestamp>${git.commit.time}</reproducible.build.timestamp>
         <project.build.outputTimestamp>${reproducible.build.timestamp}</project.build.outputTimestamp>
         <test.args>-Duser.language=en</test.args>
+        <ossindex.skip>false</ossindex.skip>
     </properties>
     <licenses>
         <license>
@@ -485,6 +486,7 @@
                 <version>3.2.0</version>
                 <configuration>
                     <authId>ossindex</authId>
+                    <skip>${ossindex.skip}</skip>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
This avoids running ossindex multiple times for a single PR run.