### PR TITLE
Feature/352 tag parsing in xml documents

### DIFF
--- a/api/src/main/java/org/itsallcode/openfasttrace/api/importer/ImporterFactory.java
+++ b/api/src/main/java/org/itsallcode/openfasttrace/api/importer/ImporterFactory.java
@@ -21,6 +21,18 @@ public abstract class ImporterFactory implements Initializable<ImporterContext>
     }
 
     /**
+     * Get the priority of this {@link ImporterFactory}.
+     * <p>
+     * The priority is used to determine the order in which importer factories
+     * are tried when importing a file. Lower priority values indicate higher
+     * precedence.
+     * </p>
+     * 
+     * @return priority of this importer factory
+     */
+    public abstract int getPriority();
+
+    /**
      * Returns {@code true} if this {@link ImporterFactory} supports
      * importing the given file based on its file extension.
      *

--- a/core/src/main/java/org/itsallcode/openfasttrace/core/importer/ImporterFactoryLoader.java
+++ b/core/src/main/java/org/itsallcode/openfasttrace/core/importer/ImporterFactoryLoader.java
@@ -1,6 +1,7 @@
 package org.itsallcode.openfasttrace.core.importer;
 
 import java.nio.file.Path;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
@@ -17,7 +18,6 @@ import org.itsallcode.openfasttrace.core.serviceloader.Loader;
 public class ImporterFactoryLoader
 {
     private static final Logger LOG = Logger.getLogger(ImporterFactoryLoader.class.getName());
-
     private final Loader<ImporterFactory> serviceLoader;
 
     /**
@@ -45,29 +45,27 @@ public class ImporterFactoryLoader
 
     /**
      * Finds a matching {@link ImporterFactory} that can handle the given
-     * {@link Path}. If no or more than one {@link ImporterFactory} is found,
-     * this throws an {@link ImporterException}.
+     * {@link Path}. If no {@link ImporterFactory} is found, this throws an
+     * {@link ImporterException}.
      *
      * @param file
      *            the file for which to get a {@link ImporterFactory}.
      * @return a matching {@link ImporterFactory} that can handle the given
      *         {@link Path}
      * @throws ImporterException
-     *             when no or more than one {@link ImporterFactory} is found.
+     *             when no {@link ImporterFactory} is found.
      */
     public Optional<ImporterFactory> getImporterFactory(final InputFile file)
     {
-        final List<ImporterFactory> matchingImporters = getMatchingFactories(file);
-        switch (matchingImporters.size())
+        final List<ImporterFactory> matchingImporters = getMatchingFactoriesInOrderOfPriority(file);
+        if (matchingImporters.isEmpty())
         {
-        case 0:
             LOG.info(() -> "Found no matching importer for file '" + file + "'");
             return Optional.empty();
-        case 1:
+        }
+        else
+        {
             return Optional.of(matchingImporters.get(0));
-        default:
-            LOG.info(() -> "Found more than one matching importer for file '" + file + "'");
-            return Optional.empty();
         }
     }
 
@@ -81,12 +79,12 @@ public class ImporterFactoryLoader
      */
     public boolean supportsFile(final InputFile file)
     {
-        final boolean supported = !getMatchingFactories(file).isEmpty();
+        final boolean supported = !getMatchingFactoriesInOrderOfPriority(file).isEmpty();
         LOG.finest(() -> "File " + file + " is supported = " + supported);
         return supported;
     }
 
-    private List<ImporterFactory> getMatchingFactories(final InputFile file)
+    private List<ImporterFactory> getMatchingFactoriesInOrderOfPriority(final InputFile file)
     {
         final List<ImporterFactory> allFactories = this.serviceLoader.load().toList();
         if (allFactories.isEmpty())
@@ -96,6 +94,7 @@ public class ImporterFactoryLoader
         }
         return allFactories.stream()
                 .filter(f -> f.supportsFile(file))
+                .sorted(Comparator.comparingInt(ImporterFactory::getPriority))
                 .toList();
     }
 }

--- a/core/src/test/java/org/itsallcode/openfasttrace/core/importer/TestImporterFactoryLoader.java
+++ b/core/src/test/java/org/itsallcode/openfasttrace/core/importer/TestImporterFactoryLoader.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.*;
 
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Optional;
 
 import org.itsallcode.openfasttrace.api.importer.ImporterException;
 import org.itsallcode.openfasttrace.api.importer.ImporterFactory;
@@ -84,6 +85,13 @@ class TestImporterFactoryLoader {
         when(priority3Factory.getPriority()).thenReturn(3);
         simulateFactories(priority2Factory, priority1Factory, priority3Factory);
         assertThat(this.loader.getImporterFactory(this.file).orElseThrow().getPriority(), equalTo(1));
+    }
+
+    @Test
+    void testNoMatchingFactoriesReturnsEmpty(@Mock final ImporterFactory unused) {
+        when(unused.supportsFile(same(this.file))).thenReturn(false);
+        simulateFactories(unused);
+        assertThat(this.loader.getImporterFactory(this.file), equalTo(Optional.empty()));
     }
 
     private void assertFactoryFound(final ImporterFactory expectedFactory) {

--- a/core/src/test/java/org/itsallcode/openfasttrace/core/importer/TestImporterFactoryLoader.java
+++ b/core/src/test/java/org/itsallcode/openfasttrace/core/importer/TestImporterFactoryLoader.java
@@ -94,6 +94,12 @@ class TestImporterFactoryLoader {
         assertThat(this.loader.getImporterFactory(this.file), equalTo(Optional.empty()));
     }
 
+    @Test
+    void testSupportsFile() {
+        simulateFactories(this.supportedFactory1);
+        assertThat(this.loader.supportsFile(this.file), equalTo(true));
+    }
+
     private void assertFactoryFound(final ImporterFactory expectedFactory) {
         assertThat(this.loader.getImporterFactory(this.file).orElseThrow(
                 () -> new AssertionError("Unable to find ImporterFactory.")), sameInstance(expectedFactory));

--- a/core/src/test/java/org/itsallcode/openfasttrace/core/importer/TestImporterFactoryLoader.java
+++ b/core/src/test/java/org/itsallcode/openfasttrace/core/importer/TestImporterFactoryLoader.java
@@ -1,12 +1,11 @@
 package org.itsallcode.openfasttrace.core.importer;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.same;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -26,8 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * Test for {@link ImporterFactoryLoader}
  */
 @ExtendWith(MockitoExtension.class)
-class TestImporterFactoryLoader
-{
+class TestImporterFactoryLoader {
     @Mock
     private Loader<ImporterFactory> serviceLoaderMock;
     @Mock
@@ -41,8 +39,7 @@ class TestImporterFactoryLoader
     private InputFile file;
 
     @BeforeEach
-    void beforeEach()
-    {
+    void beforeEach() {
         this.loader = new ImporterFactoryLoader(this.serviceLoaderMock);
         this.file = RealFileInput.forPath(Paths.get("dir", "name"));
 
@@ -52,49 +49,49 @@ class TestImporterFactoryLoader
     }
 
     @Test
-    void testNoFactoryRegisteredThrowsException()
-    {
+    void testNoFactoryRegisteredThrowsException() {
         simulateFactories();
         assertThrows(ImporterException.class, () -> this.loader.getImporterFactory(this.file));
     }
 
     @Test
-    void testSupportsFileWhenNoFactoryRegisteredThrowsException()
-    {
+    void testSupportsFileWhenNoFactoryRegisteredThrowsException() {
         simulateFactories();
         assertThrows(ImporterException.class, () -> this.loader.supportsFile(this.file));
     }
 
     @Test
-    void testMatchingFactoryFoundOnlyOneAvailable()
-    {
+    void testMatchingFactoryFoundOnlyOneAvailable() {
         simulateFactories(this.supportedFactory1);
         assertFactoryFound(this.supportedFactory1);
     }
 
     @Test
-    void testMatchingFactoryFoundTwoAvailable()
-    {
+    void testMatchingFactoryFoundTwoAvailable() {
         simulateFactories(this.supportedFactory1, this.unsupportedFactory);
         assertFactoryFound(this.supportedFactory1);
     }
 
     @Test
-    void testMultipleMatchingFactoriesFoundReturnNoImporter()
-    {
-        simulateFactories(this.supportedFactory1, this.supportedFactory1);
-        assertTrue(this.loader.getImporterFactory(this.file).isEmpty());
+    void testMultipleMatchingFactoriesReturnsTopPriority(@Mock ImporterFactory priority1Factory,
+                                                         @Mock ImporterFactory priority2Factory,
+                                                         @Mock ImporterFactory priority3Factory) {
+        when(priority1Factory.supportsFile(same(this.file))).thenReturn(true);
+        when(priority2Factory.supportsFile(same(this.file))).thenReturn(true);
+        when(priority3Factory.supportsFile(same(this.file))).thenReturn(true);
+        when(priority1Factory.getPriority()).thenReturn(1);
+        when(priority2Factory.getPriority()).thenReturn(2);
+        when(priority3Factory.getPriority()).thenReturn(3);
+        simulateFactories(priority2Factory, priority1Factory, priority3Factory);
+        assertThat(this.loader.getImporterFactory(this.file).orElseThrow().getPriority(), equalTo(1));
     }
 
-    private void assertFactoryFound(final ImporterFactory expectedFactory)
-    {
-        assertThat(this.loader.getImporterFactory(this.file).orElseThrow(() ->
-                new AssertionError("Unable to find ImporterFactory.")
-        ), sameInstance(expectedFactory));
+    private void assertFactoryFound(final ImporterFactory expectedFactory) {
+        assertThat(this.loader.getImporterFactory(this.file).orElseThrow(
+                () -> new AssertionError("Unable to find ImporterFactory.")), sameInstance(expectedFactory));
     }
 
-    private void simulateFactories(final ImporterFactory... factories)
-    {
+    private void simulateFactories(final ImporterFactory... factories) {
         when(this.serviceLoaderMock.load()).thenReturn(Arrays.stream(factories));
     }
 }

--- a/doc/changes/changes_4.5.0.md
+++ b/doc/changes/changes_4.5.0.md
@@ -10,10 +10,13 @@ We also refactored the tests around the CLI starter to improve readability and m
 
 We added FXML to the list of supported file formats for the tag importer.
 
+File extensions can now be handled by multiple importers. Importers have a priority order, the first importer that can handle a file extension will be used. Since the XML importer has a peek function to detect SpecObject files, it can decide not to handle an XML file, in which case the tag importer can take over.
+
 When no importer factory is found for a given file format, the importer factory loader will now throw an exception that explains the likely cause. This is helpful in case OFT is used as a library with a custom classloader and thus does not have the right context.
 
 ## Features
 
+* #352: Tag parsing in XML documents
 * #503: Added `-h` / `--help` to the command line.
 * #524: Added version number to help text.
 * #506: Exception when no importer was found.

--- a/doc/spec/design.md
+++ b/doc/spec/design.md
@@ -178,7 +178,51 @@ Depending on the source format, a variety of [importers](#importers) takes care 
 
 The listener handles Common parts of the import like filtering out unnecessary items or attributes.
 
-A factory for importers decides which importer to use. Usually, by file extension.
+The following sequence diagram illustrates the interaction between `MultiFileImporter`, `ImporterFactoryLoader`, `ImporterFactory`, and `Importer` during the import process:
+
+```puml
+@startuml
+participant MultiFileImporterImpl as MFI
+participant ImporterFactoryLoader as IFL
+participant ImporterFactory as IF
+participant Importer as I
+participant SpecificationListBuilder as SLB
+
+[-> MFI : importFile(file)
+activate MFI
+MFI -> IFL : getImporterFactory(file)
+activate IFL
+IFL -> IF : supportsFile(file)
+activate IF
+return true
+IFL -> IF : getPriority()
+activate IF
+return priority
+note over IFL: Choose factory with\nlowest priority value
+return factory
+MFI -> IF : createImporter(file, specItemBuilder)
+activate IF
+create I
+IF -> I : new
+return importer
+MFI -> I : runImport()
+activate I
+I -> SLB : event(item)
+activate SLB
+return
+return
+return
+@enduml
+```
+
+A factory for importers decides which importer to use. When multiple importers support the same file, the one with the lowest priority value (highest precedence) is chosen. Usually, importers are selected based on file extension, but some importers may peek into the file content to determine compatibility.
+
+The default priorities for standard importers are:
+1. Markdown Importer: 1000
+2. reStructuredText Importer: 2000
+3. Specobject (ReqM2) Importer: 3000
+4. Tag Importer: 10000
+5. Zip Importer: 20000
 
 ### ReqM2 File Detection
 `dsn~import.reqm2-file-detection~1`
@@ -187,6 +231,8 @@ The `SpecobjectImporterFactory` detects ReqM2 files either
 
 1. via the file extension `.oreqm` or
 2. via the file extension `.xml` and the presence of the string `<specdocument` within the first 4096 bytes of the file.
+
+Since the Tag Importer also supports `.xml` files but has a higher priority value (10000 vs 3000), `.xml` files containing the `<specdocument` tag will be handled by the Specobject Importer. Only if the file does not contain the tag will it fall back to the Tag Importer.
 
 Covers:
 

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -794,6 +794,7 @@ recognized file types:
 
 * HTML (`.html`, `.htm`, `.xhtml`)
 * YAML (`.yaml`, `.yml`)
+* XML (`xml`)
 
 **Modeling languages**
 

--- a/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MarkdownImporterFactory.java
+++ b/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MarkdownImporterFactory.java
@@ -15,6 +15,12 @@ public class MarkdownImporterFactory extends RegexMatchingImporterFactory
     }
 
     @Override
+    public int getPriority()
+    {
+        return 1000;
+    }
+
+    @Override
     public Importer createImporter(final InputFile fileName, final ImportEventListener listener)
     {
         return new MarkdownImporter(fileName, listener);

--- a/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/TestMarkdownImporterFactory.java
+++ b/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/TestMarkdownImporterFactory.java
@@ -18,6 +18,11 @@ class TestMarkdownImporterFactory extends ImporterFactoryTestBase<MarkdownImport
     }
 
     @Override
+    protected int getExpectedPriority() {
+        return 1000;
+    }
+
+    @Override
     protected List<String> getSupportedFilenames()
     {
         return asList("file.md", "file.MD", "FILE.md", "FILE.MD", "file.markdown", "file.MARKDOWN",

--- a/importer/restructuredtext/src/main/java/org/itsallcode/openfasttrace/importer/restructuredtext/RestructuredTextImporterFactory.java
+++ b/importer/restructuredtext/src/main/java/org/itsallcode/openfasttrace/importer/restructuredtext/RestructuredTextImporterFactory.java
@@ -15,6 +15,11 @@ public class RestructuredTextImporterFactory extends RegexMatchingImporterFactor
     }
 
     @Override
+    public int getPriority() {
+        return 2000;
+    }
+
+    @Override
     public Importer createImporter(final InputFile fileName, final ImportEventListener listener)
     {
         return new RestructuredTextImporter(fileName, listener);

--- a/importer/restructuredtext/src/test/java/org/itsallcode/openfasttrace/importer/restructuredtext/TestRestructuredTextImporterFactory.java
+++ b/importer/restructuredtext/src/test/java/org/itsallcode/openfasttrace/importer/restructuredtext/TestRestructuredTextImporterFactory.java
@@ -18,6 +18,11 @@ class TestRestructuredTextImporterFactory extends ImporterFactoryTestBase<Restru
     }
 
     @Override
+    protected int getExpectedPriority() {
+        return 2000;
+    }
+
+    @Override
     protected List<String> getSupportedFilenames()
     {
         return asList("file.rst", "file.RST", "FILE.rst", "FILE.RST");

--- a/importer/specobject/src/main/java/org/itsallcode/openfasttrace/importer/specobject/SpecobjectImporterFactory.java
+++ b/importer/specobject/src/main/java/org/itsallcode/openfasttrace/importer/specobject/SpecobjectImporterFactory.java
@@ -27,6 +27,11 @@ public class SpecobjectImporterFactory extends ImporterFactory
         this.xmlParserFactory = new XmlParserFactory();
     }
 
+    @Override
+    public int getPriority() {
+        return 3000;
+    }
+
     // [impl -> dsn~import.reqm2-file-detection~1]
     @Override
     public boolean supportsFile(final InputFile file)

--- a/importer/specobject/src/test/java/org/itsallcode/openfasttrace/importer/specobject/TestSpecobjectImporterFactory.java
+++ b/importer/specobject/src/test/java/org/itsallcode/openfasttrace/importer/specobject/TestSpecobjectImporterFactory.java
@@ -23,11 +23,15 @@ import org.mockito.Mock;
 class TestSpecobjectImporterFactory
         extends ImporterFactoryTestBase<SpecobjectImporterFactory>
 {
-
     @Override
     protected SpecobjectImporterFactory createFactory()
     {
         return new SpecobjectImporterFactory();
+    }
+
+    @Override
+    protected int getExpectedPriority() {
+        return 3000;
     }
 
     /**

--- a/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/TagImporterFactory.java
+++ b/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/TagImporterFactory.java
@@ -23,7 +23,7 @@ public class TagImporterFactory extends ImporterFactory
             "feature", // Gherkin feature files
             "go", // Go
             "groovy", // Groovy
-            "json", "htm", "html", "xhtml", "yaml", "yml", // markup languages
+            "json", "htm", "html", "xhtml", "xml", "yaml", "yml", // markup languages
             "fxml", "java", // Java
             "clj", "kt", "kts", "scala", // JVM languages
             "js", "mjs", "cjs", "ejs", // JavaScript
@@ -54,6 +54,12 @@ public class TagImporterFactory extends ImporterFactory
     {
         // empty by intention
     }
+
+    @Override
+    public int getPriority() {
+        return 10000;
+    }
+
 
     @Override
     public boolean supportsFile(final InputFile path)

--- a/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporterFactory.java
+++ b/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporterFactory.java
@@ -44,4 +44,10 @@ class TestTagImporterFactory extends ImporterFactoryTestBase<TagImporterFactory>
         return asList("file.md", "file.jav", "file.ml", "file.1java", "file.java1", "file.java.md",
                 "file_java", "filejava");
     }
+
+    @Override
+    protected int getExpectedPriority()
+    {
+        return 10000;
+    }
 }

--- a/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporterFactory.java
+++ b/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporterFactory.java
@@ -32,7 +32,8 @@ class TestTagImporterFactory extends ImporterFactoryTestBase<TagImporterFactory>
                 "foo.ts", "foo.json",
                 "foo.lua", "foo.m", "foo.mm", "foo.php", "foo.pl", "foo.pls", "foo.pm", "foo.proto", "foo.py",
                 "foo.sql", "foo.r",
-                "foo.rs", "foo.sh", "foo.sv", "foo.v", "foo.inc", "foo.yaml", "foo.yml", "foo.xhtml", "foo.zsh",
+                "foo.rs", "foo.sh", "foo.sv", "foo.v", "foo.inc", "foo.yaml", "foo.yml", "foo.xhtml", "foo.xml",
+                "foo.zsh",
                 "foo.clj", "foo.kt", "foo.scala",
                 "foo.pu", "foo.puml", "foo.plantuml", "foo.go", "foo.robot", "foo.tf", "foo.tfvars", "foo.toml");
     }

--- a/importer/zip/src/main/java/org/itsallcode/openfasttrace/importer/zip/ZipFileImporterFactory.java
+++ b/importer/zip/src/main/java/org/itsallcode/openfasttrace/importer/zip/ZipFileImporterFactory.java
@@ -19,6 +19,11 @@ public class ZipFileImporterFactory extends RegexMatchingImporterFactory
     }
 
     @Override
+    public int getPriority() {
+        return 10000;
+    }
+
+    @Override
     public Importer createImporter(final InputFile file, final ImportEventListener listener)
     {
         return new ZipFileImporter(getContext().getImporterService(), file, listener);

--- a/importer/zip/src/main/java/org/itsallcode/openfasttrace/importer/zip/ZipFileImporterFactory.java
+++ b/importer/zip/src/main/java/org/itsallcode/openfasttrace/importer/zip/ZipFileImporterFactory.java
@@ -20,7 +20,7 @@ public class ZipFileImporterFactory extends RegexMatchingImporterFactory
 
     @Override
     public int getPriority() {
-        return 10000;
+        return 20000;
     }
 
     @Override

--- a/importer/zip/src/test/java/org/itsallcode/openfasttrace/importer/zip/TestZipFileImporterFactory.java
+++ b/importer/zip/src/test/java/org/itsallcode/openfasttrace/importer/zip/TestZipFileImporterFactory.java
@@ -20,7 +20,7 @@ class TestZipFileImporterFactory extends ImporterFactoryTestBase<ZipFileImporter
     private ImporterService importerServiceMock;
 
     @BeforeEach
-    public void configureMock()
+    void configureMock()
     {
         lenient().when(this.contextMock.getImporterService()).thenReturn(this.importerServiceMock);
     }
@@ -29,6 +29,12 @@ class TestZipFileImporterFactory extends ImporterFactoryTestBase<ZipFileImporter
     void testConstructor()
     {
         assertThat(createFactory(), notNullValue());
+    }
+
+    @Override
+    protected int getExpectedPriority()
+    {
+        return 20000;
     }
 
     @Override

--- a/product/src/test/java/org/itsallcode/openfasttrace/importer/ImporterFactoryLoaderIT.java
+++ b/product/src/test/java/org/itsallcode/openfasttrace/importer/ImporterFactoryLoaderIT.java
@@ -1,0 +1,45 @@
+package org.itsallcode.openfasttrace.importer;
+
+import org.itsallcode.openfasttrace.api.FilterSettings;
+import org.itsallcode.openfasttrace.api.core.SpecificationItem;
+import org.itsallcode.openfasttrace.api.importer.ImportSettings;
+
+import org.itsallcode.openfasttrace.core.Oft;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+class ImporterFactoryLoaderIT {
+    @Test
+    void testFallBackToTagImporterWhenXmlIsNotSpecObjectFile(@TempDir Path tempDir) throws IOException {
+        final Oft oft = Oft.create();
+        final String specObjectContent = """
+                <specdocument>
+                    <specobjects doctype=\"dsn\">
+                        <specobject>
+                            <id>foobar</id>
+                                 <version>1</version>
+                            </specobject>
+                    </specobjects>
+                </specdocument>""";
+        Files.write(tempDir.resolve("specobject.xml"), specObjectContent.getBytes());
+        final String xmlContent = "<!-- [" + "impl -> dns~foobar~1" + "] -->";
+        Files.write(tempDir.resolve("non_specobject.xml"), xmlContent.getBytes());
+        final ImportSettings settings = ImportSettings.builder()
+                .addInputs(tempDir)
+                .filter(FilterSettings.builder().build())
+                .build();
+        final List<SpecificationItem> items = oft.importItems(settings);
+        assertThat(items, containsInAnyOrder(
+                hasProperty("id", hasToString("dsn~foobar~1")),
+                hasProperty("id", hasToString(startsWith("impl~foobar")))
+        ));
+    }
+}

--- a/product/src/test/java/org/itsallcode/openfasttrace/importer/ImporterFactoryLoaderIT.java
+++ b/product/src/test/java/org/itsallcode/openfasttrace/importer/ImporterFactoryLoaderIT.java
@@ -42,4 +42,16 @@ class ImporterFactoryLoaderIT {
                 hasProperty("id", hasToString(startsWith("impl~foobar")))
         ));
     }
+
+    @Test
+    void testNoMatchingImportersFound(@TempDir Path tempDir) throws IOException {
+        final Path fileWithUnknownExtension = tempDir.resolve("file.unknown");
+        Files.createFile(fileWithUnknownExtension);
+        final Oft oft = Oft.create();
+        final ImportSettings settings = ImportSettings.builder()
+                .addInputs(tempDir)
+                .filter(FilterSettings.builder().build())
+                .build();
+        assertThat(oft.importItems(settings), emptyIterableOf(SpecificationItem.class));
+    }
 }

--- a/product/src/test/java/org/itsallcode/openfasttrace/importer/ImporterFactoryLoaderIT.java
+++ b/product/src/test/java/org/itsallcode/openfasttrace/importer/ImporterFactoryLoaderIT.java
@@ -4,7 +4,11 @@ import org.itsallcode.openfasttrace.api.FilterSettings;
 import org.itsallcode.openfasttrace.api.core.SpecificationItem;
 import org.itsallcode.openfasttrace.api.importer.ImportSettings;
 
+import org.itsallcode.openfasttrace.api.importer.ImporterContext;
+import org.itsallcode.openfasttrace.api.importer.input.InputFile;
+import org.itsallcode.openfasttrace.api.importer.input.RealFileInput;
 import org.itsallcode.openfasttrace.core.Oft;
+import org.itsallcode.openfasttrace.core.importer.ImporterFactoryLoader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -12,6 +16,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -46,13 +51,14 @@ class ImporterFactoryLoaderIT {
     @Test
     void testNoMatchingImportersFound(@TempDir Path tempDir) throws IOException {
         final Path pathTofileWithUnknownExtension = tempDir.resolve("file.unknown");
-        final Path fileWithUnknownExtension = Files.createFile(pathTofileWithUnknownExtension);
-        final Oft oft = Oft.create();
+        Files.createFile(pathTofileWithUnknownExtension);
+        final InputFile inputFile = RealFileInput.forPath(pathTofileWithUnknownExtension);
         final ImportSettings settings = ImportSettings.builder()
-                // We must feed a file, not a path to trigger this code path.
-                .addInputs(fileWithUnknownExtension)
+                .addInputs(pathTofileWithUnknownExtension)
                 .filter(FilterSettings.builder().build())
                 .build();
-        assertThat(oft.importItems(settings), emptyIterableOf(SpecificationItem.class));
+        final ImporterContext importerContext = new ImporterContext(settings);
+        final ImporterFactoryLoader loader = new ImporterFactoryLoader(importerContext);
+        assertThat(loader.getImporterFactory(inputFile), equalTo(Optional.empty()));
     }
 }

--- a/product/src/test/java/org/itsallcode/openfasttrace/importer/ImporterFactoryLoaderIT.java
+++ b/product/src/test/java/org/itsallcode/openfasttrace/importer/ImporterFactoryLoaderIT.java
@@ -45,11 +45,12 @@ class ImporterFactoryLoaderIT {
 
     @Test
     void testNoMatchingImportersFound(@TempDir Path tempDir) throws IOException {
-        final Path fileWithUnknownExtension = tempDir.resolve("file.unknown");
-        Files.createFile(fileWithUnknownExtension);
+        final Path pathTofileWithUnknownExtension = tempDir.resolve("file.unknown");
+        final Path fileWithUnknownExtension = Files.createFile(pathTofileWithUnknownExtension);
         final Oft oft = Oft.create();
         final ImportSettings settings = ImportSettings.builder()
-                .addInputs(tempDir)
+                // We must feed a file, not a path to trigger this code path.
+                .addInputs(fileWithUnknownExtension)
                 .filter(FilterSettings.builder().build())
                 .build();
         assertThat(oft.importItems(settings), emptyIterableOf(SpecificationItem.class));

--- a/product/src/test/java/org/itsallcode/openfasttrace/importer/ImporterFactoryLoaderIT.java
+++ b/product/src/test/java/org/itsallcode/openfasttrace/importer/ImporterFactoryLoaderIT.java
@@ -22,7 +22,7 @@ class ImporterFactoryLoaderIT {
         final Oft oft = Oft.create();
         final String specObjectContent = """
                 <specdocument>
-                    <specobjects doctype=\"dsn\">
+                    <specobjects doctype="dsn">
                         <specobject>
                             <id>foobar</id>
                                  <version>1</version>

--- a/product/src/test/java/org/itsallcode/openfasttrace/importer/ImporterFactoryLoaderIT.java
+++ b/product/src/test/java/org/itsallcode/openfasttrace/importer/ImporterFactoryLoaderIT.java
@@ -4,11 +4,7 @@ import org.itsallcode.openfasttrace.api.FilterSettings;
 import org.itsallcode.openfasttrace.api.core.SpecificationItem;
 import org.itsallcode.openfasttrace.api.importer.ImportSettings;
 
-import org.itsallcode.openfasttrace.api.importer.ImporterContext;
-import org.itsallcode.openfasttrace.api.importer.input.InputFile;
-import org.itsallcode.openfasttrace.api.importer.input.RealFileInput;
 import org.itsallcode.openfasttrace.core.Oft;
-import org.itsallcode.openfasttrace.core.importer.ImporterFactoryLoader;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -16,7 +12,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -46,19 +41,5 @@ class ImporterFactoryLoaderIT {
                 hasProperty("id", hasToString("dsn~foobar~1")),
                 hasProperty("id", hasToString(startsWith("impl~foobar")))
         ));
-    }
-
-    @Test
-    void testNoMatchingImportersFound(@TempDir Path tempDir) throws IOException {
-        final Path pathTofileWithUnknownExtension = tempDir.resolve("file.unknown");
-        Files.createFile(pathTofileWithUnknownExtension);
-        final InputFile inputFile = RealFileInput.forPath(pathTofileWithUnknownExtension);
-        final ImportSettings settings = ImportSettings.builder()
-                .addInputs(pathTofileWithUnknownExtension)
-                .filter(FilterSettings.builder().build())
-                .build();
-        final ImporterContext importerContext = new ImporterContext(settings);
-        final ImporterFactoryLoader loader = new ImporterFactoryLoader(importerContext);
-        assertThat(loader.getImporterFactory(inputFile), equalTo(Optional.empty()));
     }
 }

--- a/testutil/src/main/java/org/itsallcode/openfasttrace/testutil/importer/ImporterFactoryTestBase.java
+++ b/testutil/src/main/java/org/itsallcode/openfasttrace/testutil/importer/ImporterFactoryTestBase.java
@@ -93,6 +93,18 @@ public abstract class ImporterFactoryTestBase<T extends ImporterFactory>
                 "Context was not initialized");
     }
 
+    @Test
+    void testGetPriority() {
+        assertThat(createFactory().getPriority(), equalTo(getExpectedPriority()));
+    }
+
+    /**
+     * Get the priority the importer factory should report.
+     *
+     * @return expected priority
+     */
+    protected abstract int getExpectedPriority();
+
     private void assertSupported(final List<String> filenames, final boolean expectedResult)
     {
         final T factory = createFactory();

--- a/testutil/src/test/java/org/itsallcode/openfasttrace/testutil/importer/ImporterFactoryTestBaseTest.java
+++ b/testutil/src/test/java/org/itsallcode/openfasttrace/testutil/importer/ImporterFactoryTestBaseTest.java
@@ -26,6 +26,11 @@ class ImporterFactoryTestBaseTest
         }
 
         @Override
+        protected int getExpectedPriority() {
+            return 0;
+        }
+
+        @Override
         protected List<String> getSupportedFilenames()
         {
             throw new UnsupportedOperationException("Unimplemented method 'getSupportedFilenames'");

--- a/testutil/src/test/java/org/itsallcode/openfasttrace/testutil/importer/ImporterFactoryTestBaseTest.java
+++ b/testutil/src/test/java/org/itsallcode/openfasttrace/testutil/importer/ImporterFactoryTestBaseTest.java
@@ -41,6 +41,11 @@ class ImporterFactoryTestBaseTest
     private static class DummyImporterFactory extends ImporterFactory
     {
         @Override
+        public int getPriority() {
+            return 99999999;
+        }
+
+        @Override
         public boolean supportsFile(final InputFile file)
         {
             throw new UnsupportedOperationException("Unimplemented method 'supportsFile'");


### PR DESCRIPTION
Introduced priorities in importer factories to allow having more than one supporting a file extension and still getting back a single result in a controlled manner.

This allowed me to introduce `.xml` in the tag importer. The tag importer has a lower priority than the SpecObject importer. Since the SpecObject importer peeks into the XML files and refuses to support them when the expected header is missing, the tag importer gets its chance on non-SpecObject XML.

@g-psantos , that should do the trick for annotating regular XML files with coverage. I know, this one has been long in the making, but I needed to figure out a way that could be done with minimal changes.

Closes #352.