### PR TITLE
added coverage of multiple ids in tags

### DIFF
--- a/.agents/skills/openfasttrace/SKILL.md
+++ b/.agents/skills/openfasttrace/SKILL.md
@@ -60,7 +60,13 @@ Coverage in a YMAL file (e.g., GitHub workflow)
 Require coverage:
 
 ```plantuml
-# [req -> dsn~hash-sum-calculation~1 >> impl, utest]
+' [req -> dsn~hash-sum-calculation~1 >> impl, utest]
+```
+
+Multiple coverage:
+
+```Java
+// [dsn -> req~local-stability~1,arch~dimensional-input~1]
 ```
 
 ## Tracing

--- a/doc/changes/changes_4.6.0.md
+++ b/doc/changes/changes_4.6.0.md
@@ -19,3 +19,7 @@ We moved some GitHub action permissions from workflow-level to job-level.
 * #546: Replaced `OsDetector` with JUnit5's `EnabledOnOs` annotation.
 * #544: Replaced optional parameter with null check
 * #543: Made `CliException` a `RuntimeException`
+
+## Features
+
+* #553 Tag importer supports multiple covered ids

--- a/doc/changes/changes_4.6.0.md
+++ b/doc/changes/changes_4.6.0.md
@@ -22,4 +22,4 @@ We moved some GitHub action permissions from workflow-level to job-level.
 
 ## Features
 
-* #553 Tag importer supports multiple covered ids
+* #553 Tag importer supports multiple covered IDs

--- a/doc/spec/design.md
+++ b/doc/spec/design.md
@@ -889,6 +889,24 @@ Covers:
 
 Needs: impl, utest
 
+#### Full Coverage Tag Format Allows Multiple Coverage
+`dsn~import.full-coverage-tag-multiple-needed-coverage~1`
+
+OFT imports full coverage tags with multiple need coverage ids:
+
+    full-tag-multiple-coverage-id =
+        "[" *WSP reference *WSP "->" *WSP requirement-id *WSP *("," *WSP requirement-id) *WSP "]"
+
+Rationale:
+
+An item can cover multiple IDs. This avoids creating multiple IDs for the same item solely to represent multiple coverage relations. It also reduces the number of IDs that related items must reference for complete coverage, improving readability and maintainability.
+
+Covers:
+
+* `req~import.full-coverage-tag-format~1`
+
+Needs: impl, utest
+
 #### Full Coverage Tag Format Allows Specifying a Revision
 `dsn~import.full-coverage-tag-with-revision~1`
 

--- a/doc/user_guide.md
+++ b/doc/user_guide.md
@@ -708,7 +708,7 @@ To avoid conflict with the formats actual contents, you embed these definitions 
 Tags have the following format:
 
 ```
-[ <covered-artifact-type> -> <specification-object-id> ]
+[ <covered-artifact-type> -> <list-of-specification-object-ids> ]
 ```
 
 Spaces above were only added for readability. They are optional. In fact usually people prefer a more compact form.
@@ -737,7 +737,7 @@ Examples:
 // [impl~validate-password~2->dsn~validate-authentication-request~1]
 ```
 
-##### Forwarding Requirements
+##### Needed Coverage
 
 When using UML models as design document files like UML models it is useful to add needed coverage as well. To do this, you can use the following format:
 

--- a/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/LongTagImportingLineConsumer.java
+++ b/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/LongTagImportingLineConsumer.java
@@ -2,7 +2,9 @@ package org.itsallcode.openfasttrace.importer.tag;
 
 import static java.util.Collections.emptyList;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
@@ -23,18 +25,21 @@ class LongTagImportingLineConsumer extends AbstractRegexLineConsumer
     private static final String OPTIONAL_WHITESPACE = "\\s*";
     private static final String TAG_PREFIX = "\\[";
     private static final String TAG_SUFFIX = "\\]";
-    private static final String NEEDS_COVERAGE = ">>" + OPTIONAL_WHITESPACE + "(\\p{Alpha}+(?:"
-            + OPTIONAL_WHITESPACE
-            + "," + OPTIONAL_WHITESPACE + "\\p{Alpha}+)*)";
+    private static final String COVERED_IDS = SpecificationItemId.ID_PATTERN + "(?:"
+            + OPTIONAL_WHITESPACE + "," + OPTIONAL_WHITESPACE + SpecificationItemId.ID_PATTERN
+            + ")*";
+    private static final String NEEDS_COVERAGE = ">>" + OPTIONAL_WHITESPACE
+            + "(?<neededArtifactTypes>\\p{Alpha}+(?:" + OPTIONAL_WHITESPACE + ","
+            + OPTIONAL_WHITESPACE + "\\p{Alpha}+)*)";
     private static final String TAG_REGEX = TAG_PREFIX + OPTIONAL_WHITESPACE//
-            + "(" + COVERING_ARTIFACT_TYPE_PATTERN + ")"
+            + "(?<artifactType>" + COVERING_ARTIFACT_TYPE_PATTERN + ")"
             + "(?:" + SpecificationItemId.ARTIFACT_TYPE_SEPARATOR
             // [impl->dsn~import.full-coverage-tag-with-name-and-revision~1]
-            + "(" + SpecificationItemId.ITEM_NAME_PATTERN + ")?"
+            + "(?<customName>" + SpecificationItemId.ITEM_NAME_PATTERN + ")?"
             + SpecificationItemId.REVISION_SEPARATOR
-            + SpecificationItemId.ITEM_REVISION_PATTERN + ")?" //
+            + "(?<revision>" + SpecificationItemId.ITEM_REVISION_PATTERN + "))?" //
             + OPTIONAL_WHITESPACE + "->" + OPTIONAL_WHITESPACE //
-            + "(" + SpecificationItemId.ID_PATTERN + ")" //
+            + "(?<coveredIds>" + COVERED_IDS + ")" //
             + OPTIONAL_WHITESPACE + "(?:" + NEEDS_COVERAGE + OPTIONAL_WHITESPACE + ")?" //
             + TAG_SUFFIX;
 
@@ -53,18 +58,27 @@ class LongTagImportingLineConsumer extends AbstractRegexLineConsumer
     {
         this.listener.beginSpecificationItem();
         this.listener.setLocation(this.file.getPath(), lineNumber);
-        final SpecificationItemId coveredId = SpecificationItemId.parseId(matcher.group(5));
-        final List<String> neededArtifactTypes = parseCommaSeparatedList(matcher.group(9));
-        final SpecificationItemId generatedId = createItemId(matcher, lineNumber, lineMatchCount, coveredId,
-                neededArtifactTypes);
-        logItem(lineNumber, coveredId, neededArtifactTypes, generatedId);
+        final List<SpecificationItemId> coveredIds = parseCoveredIds(matcher.group("coveredIds"));
+        final List<String> neededArtifactTypes = parseNeededArtifactTypes(matcher.group("neededArtifactTypes"));
+        final SpecificationItemId generatedId = createItemId(matcher, lineNumber, lineMatchCount,
+                coveredIds, neededArtifactTypes);
+        logItem(lineNumber, coveredIds, neededArtifactTypes, generatedId);
         this.listener.setId(generatedId);
-        this.listener.addCoveredId(coveredId);
-        neededArtifactTypes.forEach(listener::addNeededArtifactType);
+        coveredIds.forEach(this.listener::addCoveredId);
+        neededArtifactTypes.forEach(this.listener::addNeededArtifactType);
         this.listener.endSpecificationItem();
     }
 
-    private static List<String> parseCommaSeparatedList(final String input)
+    private static List<SpecificationItemId> parseCoveredIds(final String input)
+    {
+        return Arrays.stream(input.split(","))
+                .map(String::trim)
+                .filter(Predicate.not(String::isEmpty))
+                .map(SpecificationItemId::parseId)
+                .toList();
+    }
+
+    private static List<String> parseNeededArtifactTypes(final String input)
     {
         if (input == null)
         {
@@ -78,28 +92,28 @@ class LongTagImportingLineConsumer extends AbstractRegexLineConsumer
     }
 
     private SpecificationItemId createItemId(final Matcher matcher, final int lineNumber, final int lineMatchCount,
-            final SpecificationItemId coveredId, final List<String> neededArtifactTypes)
+            final List<SpecificationItemId> coveredIds, final List<String> neededArtifactTypes)
     {
-        final String artifactType = matcher.group(1);
-        final String customName = matcher.group(2);
-        final String revision = matcher.group(4);
+        final String artifactType = matcher.group("artifactType");
+        final String customName = matcher.group("customName");
+        final String revision = matcher.group("revision");
         final String name = customName != null ? customName
-                : getItemName(lineNumber, lineMatchCount, coveredId, neededArtifactTypes);
+                : getItemName(lineNumber, lineMatchCount, coveredIds, neededArtifactTypes);
         return SpecificationItemId.createId(artifactType, name, parseRevision(revision));
     }
 
-    private void logItem(final int lineNumber, final SpecificationItemId coveredId,
+    private void logItem(final int lineNumber, final List<SpecificationItemId> coveredIds,
             final List<String> neededArtifactTypes, final SpecificationItemId generatedId)
     {
         if (neededArtifactTypes.isEmpty())
         {
             LOG.finest(() -> "File " + this.file + ":" + lineNumber + ": found '" + generatedId
-                    + "' covering id '" + coveredId);
+                    + "' covering ids " + coveredIds);
         }
         else
         {
             LOG.finest(() -> "File " + this.file + ":" + lineNumber + ": found '" + generatedId
-                    + "' covering id '" + coveredId + "', needs artifact types "
+                    + "' covering ids " + coveredIds + ", needs artifact types "
                     + neededArtifactTypes);
         }
     }
@@ -112,21 +126,32 @@ class LongTagImportingLineConsumer extends AbstractRegexLineConsumer
     }
 
     // [impl->dsn~import.full-coverage-tag-with-needed-coverage-readable-names~1]
-    private String getItemName(final int lineNumber, final int lineMatchCount, final SpecificationItemId coveredId,
-            final List<String> neededArtifactTypes)
+    private String getItemName(final int lineNumber, final int lineMatchCount,
+            final List<SpecificationItemId> coveredIds, final List<String> neededArtifactTypes)
     {
         if (neededArtifactTypes.isEmpty())
         {
-            return generateUniqueName(coveredId, lineNumber, lineMatchCount);
+            return generateUniqueName(coveredIds, lineNumber, lineMatchCount);
         }
-        return coveredId.getName();
+        return joinCoveredIdNamesWithHyphen(coveredIds);
     }
 
-    private String generateUniqueName(final SpecificationItemId coveredId, final int lineNumber,
+    private String generateUniqueName(final List<SpecificationItemId> coveredIds, final int lineNumber,
             final int counter)
     {
-        final String uniqueName = this.file.getPath() + lineNumber + counter + coveredId;
+        final String CoveredIdStringsJoinedWithHyphen = coveredIds.stream()
+                .map(SpecificationItemId::toString)
+                .collect(java.util.stream.Collectors.joining("-"));
+        final String uniqueName = this.file.getPath() + lineNumber + counter
+                + CoveredIdStringsJoinedWithHyphen;
         final String checksum = Long.toString(ChecksumCalculator.calculateCrc32(uniqueName));
-        return coveredId.getName() + "-" + checksum;
+        return joinCoveredIdNamesWithHyphen(coveredIds) + "-" + checksum;
+    }
+
+    private static String joinCoveredIdNamesWithHyphen(final List<SpecificationItemId> coveredIds)
+    {
+        return coveredIds.stream()
+                .map(SpecificationItemId::getName)
+                .collect(java.util.stream.Collectors.joining("-"));
     }
 }

--- a/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/LongTagImportingLineConsumer.java
+++ b/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/LongTagImportingLineConsumer.java
@@ -95,7 +95,6 @@ class LongTagImportingLineConsumer extends AbstractRegexLineConsumer
         {
             return emptyList();
         }
-
         return Arrays.stream(input.split(","))
                 .map(String::trim)
                 .filter(Predicate.not(String::isEmpty))
@@ -143,12 +142,12 @@ class LongTagImportingLineConsumer extends AbstractRegexLineConsumer
         if (neededArtifactTypes.isEmpty())
         {
             LOG.finest(() -> "File " + this.file + ":" + lineNumber + ": found '" + generatedId
-                    + "' covering ids " + coveredIds);
+                    + "' covering IDs " + coveredIds);
         }
         else
         {
             LOG.finest(() -> "File " + this.file + ":" + lineNumber + ": found '" + generatedId
-                    + "' covering ids " + coveredIds + ", needs artifact types "
+                    + "' covering IDs " + coveredIds + ", needs artifact types "
                     + neededArtifactTypes);
         }
     }

--- a/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/LongTagImportingLineConsumer.java
+++ b/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/LongTagImportingLineConsumer.java
@@ -71,6 +71,11 @@ class LongTagImportingLineConsumer extends AbstractRegexLineConsumer
 
     private static List<SpecificationItemId> parseCoveredIds(final String input)
     {
+        if (input == null)
+        {
+            return emptyList();
+        }
+
         return Arrays.stream(input.split(","))
                 .map(String::trim)
                 .filter(Predicate.not(String::isEmpty))

--- a/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/LongTagImportingLineConsumer.java
+++ b/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/LongTagImportingLineConsumer.java
@@ -56,17 +56,36 @@ class LongTagImportingLineConsumer extends AbstractRegexLineConsumer
     @Override
     public void processMatch(final Matcher matcher, final int lineNumber, final int lineMatchCount)
     {
-        this.listener.beginSpecificationItem();
-        this.listener.setLocation(this.file.getPath(), lineNumber);
         final List<SpecificationItemId> coveredIds = parseCoveredIds(matcher.group("coveredIds"));
         final List<String> neededArtifactTypes = parseNeededArtifactTypes(matcher.group("neededArtifactTypes"));
-        final SpecificationItemId generatedId = createItemId(matcher, lineNumber, lineMatchCount,
-                coveredIds, neededArtifactTypes);
-        logItem(lineNumber, coveredIds, neededArtifactTypes, generatedId);
+
+        final List<SpecificationItemId> generatedIds = createItemIds(matcher, lineNumber, lineMatchCount, coveredIds,
+                neededArtifactTypes);
+
+        if (generatedIds.size() > 1)
+        {
+            assert generatedIds.size() == coveredIds.size();
+            for (int i = 0; i < generatedIds.size(); i++)
+            {
+                addSpecificationItem(lineNumber, generatedIds.get(i), List.of(coveredIds.get(i)), neededArtifactTypes);
+            }
+        }
+        else
+        {
+            addSpecificationItem(lineNumber, generatedIds.get(0), coveredIds, neededArtifactTypes);
+        }
+    }
+
+    private void addSpecificationItem(final int lineNumber, final SpecificationItemId generatedId,
+            final List<SpecificationItemId> coveredIds, final List<String> neededArtifactTypes)
+    {
+        this.listener.beginSpecificationItem();
+        this.listener.setLocation(this.file.getPath(), lineNumber);
         this.listener.setId(generatedId);
         coveredIds.forEach(this.listener::addCoveredId);
         neededArtifactTypes.forEach(this.listener::addNeededArtifactType);
         this.listener.endSpecificationItem();
+        logItem(lineNumber, coveredIds, neededArtifactTypes, generatedId);
     }
 
     private static List<SpecificationItemId> parseCoveredIds(final String input)
@@ -96,15 +115,25 @@ class LongTagImportingLineConsumer extends AbstractRegexLineConsumer
                 .toList();
     }
 
-    private SpecificationItemId createItemId(final Matcher matcher, final int lineNumber, final int lineMatchCount,
+    private List<SpecificationItemId> createItemIds(final Matcher matcher, final int lineNumber,
+            final int lineMatchCount,
             final List<SpecificationItemId> coveredIds, final List<String> neededArtifactTypes)
     {
         final String artifactType = matcher.group("artifactType");
         final String customName = matcher.group("customName");
         final String revision = matcher.group("revision");
-        final String name = customName != null ? customName
-                : getItemName(lineNumber, lineMatchCount, coveredIds, neededArtifactTypes);
-        return SpecificationItemId.createId(artifactType, name, parseRevision(revision));
+        if (customName != null)
+        {
+            return List.of(SpecificationItemId.createId(artifactType, customName, parseRevision(revision)));
+        }
+
+        final List<SpecificationItemId> result = new java.util.ArrayList<>(coveredIds.size());
+        for (final SpecificationItemId coveredId : coveredIds)
+        {
+            final String name = getItemName(lineNumber, lineMatchCount, coveredId, neededArtifactTypes);
+            result.add(SpecificationItemId.createId(artifactType, name, parseRevision(revision)));
+        }
+        return result;
     }
 
     private void logItem(final int lineNumber, final List<SpecificationItemId> coveredIds,
@@ -131,32 +160,21 @@ class LongTagImportingLineConsumer extends AbstractRegexLineConsumer
     }
 
     // [impl->dsn~import.full-coverage-tag-with-needed-coverage-readable-names~1]
-    private String getItemName(final int lineNumber, final int lineMatchCount,
-            final List<SpecificationItemId> coveredIds, final List<String> neededArtifactTypes)
+    private String getItemName(final int lineNumber, final int lineMatchCount, final SpecificationItemId coveredId,
+            final List<String> neededArtifactTypes)
     {
         if (neededArtifactTypes.isEmpty())
         {
-            return generateUniqueName(coveredIds, lineNumber, lineMatchCount);
+            return generateUniqueName(coveredId, lineNumber, lineMatchCount);
         }
-        return joinCoveredIdNamesWithHyphen(coveredIds);
+        return coveredId.getName();
     }
 
-    private String generateUniqueName(final List<SpecificationItemId> coveredIds, final int lineNumber,
+    private String generateUniqueName(final SpecificationItemId coveredId, final int lineNumber,
             final int counter)
     {
-        final String CoveredIdStringsJoinedWithHyphen = coveredIds.stream()
-                .map(SpecificationItemId::toString)
-                .collect(java.util.stream.Collectors.joining("-"));
-        final String uniqueName = this.file.getPath() + lineNumber + counter
-                + CoveredIdStringsJoinedWithHyphen;
+        final String uniqueName = this.file.getPath() + lineNumber + counter + coveredId;
         final String checksum = Long.toString(ChecksumCalculator.calculateCrc32(uniqueName));
-        return joinCoveredIdNamesWithHyphen(coveredIds) + "-" + checksum;
-    }
-
-    private static String joinCoveredIdNamesWithHyphen(final List<SpecificationItemId> coveredIds)
-    {
-        return coveredIds.stream()
-                .map(SpecificationItemId::getName)
-                .collect(java.util.stream.Collectors.joining("-"));
+        return coveredId.getName() + "-" + checksum;
     }
 }

--- a/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/LongTagImportingLineConsumer.java
+++ b/importer/tag/src/main/java/org/itsallcode/openfasttrace/importer/tag/LongTagImportingLineConsumer.java
@@ -15,6 +15,7 @@ import org.itsallcode.openfasttrace.api.importer.input.InputFile;
 
 // [impl->dsn~import.full-coverage-tag~1]
 // [impl->dsn~import.full-coverage-tag-with-needed-coverage~1]
+// [impl->dsn~import.full-coverage-tag-multiple-needed-coverage~1]
 class LongTagImportingLineConsumer extends AbstractRegexLineConsumer
 {
     private static final Logger LOG = Logger

--- a/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporter.java
+++ b/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporter.java
@@ -91,6 +91,15 @@ class TestTagImporter
                         itemACoveringB("implA~name1-2943155783~0", "dsn~name1~2"),
                         itemACoveringB("implB~name2-1099447527~0", "dsn~name2~3"),
                         itemACoveringB("implC~name3-2846888323~0", "dsn~name3~4")),
+                parsedItem("[impl~combined~1->dsn~name1~2,dsn~name2~3]",
+                        itemBuilder().id(SpecificationItemId.parseId("impl~combined~1"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))),
+                parsedItem("[ impl~combined~1 -> dsn~name1~2 , dsn~name2~3 >> test ]",
+                        itemBuilder().id(SpecificationItemId.parseId("impl~combined~1"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))
+                                .addNeedsArtifactType("test")),
 
                 parsedItems("[implA->dsn~name1~2" + "]" + UNIX_NEWLINE + "[implB->dsn~name2~3" + "]",
                         itemACoveringB("implA~name1-2943155783~0", "dsn~name1~2"),
@@ -163,6 +172,7 @@ class TestTagImporter
                 noItemDetected("[impl~missing-revision~->dsn~name2~2]"),
                 noItemDetected("[impl~illegal?char~1->dsn~name2~2]"),
                 noItemDetected("[impl~negative-revision~-1->dsn~name2~2]"),
+                noItemDetected("[impl~missing-covered-id~1->dsn~name2~2,]"),
                 noItemDetected("[impl~missing-forward~1->dsn~name2~2>>]"),
                 noItemDetected("[impl~trailing-comma~1->dsn~name2~2>>test,]"),
                 noItemDetected("[impl~duplicate-comma~1->dsn~name2~2>>test,,other]"),

--- a/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporter.java
+++ b/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporter.java
@@ -91,6 +91,8 @@ class TestTagImporter
                         itemACoveringB("implA~name1-2943155783~0", "dsn~name1~2"),
                         itemACoveringB("implB~name2-1099447527~0", "dsn~name2~3"),
                         itemACoveringB("implC~name3-2846888323~0", "dsn~name3~4")),
+
+                // [utest->dsn~import.full-coverage-tag-multiple-needed-coverage~1]
                 parsedItem("[impl~combined~1->dsn~name1~2,dsn~name2~3" + "]",
                         itemBuilder().id(SpecificationItemId.parseId("impl~combined~1"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))

--- a/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporter.java
+++ b/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporter.java
@@ -100,6 +100,20 @@ class TestTagImporter
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))
                                 .addNeedsArtifactType("test")),
+                parsedItem("[ impl~combined~1 -> dsn~name1~2 , dsn~name2~3 >> utest,itest ]",
+                        itemBuilder().id(SpecificationItemId.parseId("impl~combined~1"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))
+                                .addNeedsArtifactType("utest")
+                                .addNeedsArtifactType("itest")),
+                parsedItem("[ impl~~1 -> dsn~name1~2 , dsn~name2~3 ]",
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name1-name2-506723840~1"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))),
+                parsedItem("[ impl -> dsn~name1~2 , dsn~name2~3 ]",
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name1-name2-506723840~0"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))),
 
                 parsedItems("[implA->dsn~name1~2" + "]" + UNIX_NEWLINE + "[implB->dsn~name2~3" + "]",
                         itemACoveringB("implA~name1-2943155783~0", "dsn~name1~2"),

--- a/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporter.java
+++ b/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporter.java
@@ -106,14 +106,49 @@ class TestTagImporter
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))
                                 .addNeedsArtifactType("utest")
                                 .addNeedsArtifactType("itest")),
-                parsedItem("[ impl~~1 -> dsn~name1~2 , dsn~name2~3 ]",
-                        itemBuilder().id(SpecificationItemId.parseId("impl~name1-name2-506723840~1"))
-                                .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
+
+                parsedItems("[ impl~~1 -> dsn~name1~2 , dsn~name2~3 ]",
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name1-2943155783~1"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name1~2")),
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name2-3660411016~1"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))),
-                parsedItem("[ impl -> dsn~name1~2 , dsn~name2~3 ]",
-                        itemBuilder().id(SpecificationItemId.parseId("impl~name1-name2-506723840~0"))
-                                .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
+                parsedItems("[ impl -> dsn~name1~2 , dsn~name2~3 ]",
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name1-2943155783~0"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name1~2")),
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name2-3660411016~0"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))),
+                parsedItems("[ impl~~1 -> dsn~name1~2 , dsn~name2~3 >> test ]",
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name1~1"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
+                                .addNeedsArtifactType("test"),
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name2~1"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))
+                                .addNeedsArtifactType("test")),
+                parsedItems("[ impl -> dsn~name1~2 , dsn~name2~3 >> test ]",
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name1~0"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
+                                .addNeedsArtifactType("test"),
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name2~0"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))
+                                .addNeedsArtifactType("test")),
+                parsedItems("[ impl~~1 -> dsn~name1~2 , dsn~name2~3 >> utest,itest ]",
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name1~1"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
+                                .addNeedsArtifactType("utest")
+                                .addNeedsArtifactType("itest"),
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name2~1"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))
+                                .addNeedsArtifactType("utest")
+                                .addNeedsArtifactType("itest")),
+                parsedItems("[ impl -> dsn~name1~2 , dsn~name2~3 >> utest,itest ]",
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name1~0"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
+                                .addNeedsArtifactType("utest")
+                                .addNeedsArtifactType("itest"),
+                        itemBuilder().id(SpecificationItemId.parseId("impl~name2~0"))
+                                .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))
+                                .addNeedsArtifactType("utest")
+                                .addNeedsArtifactType("itest")),
 
                 parsedItems("[implA->dsn~name1~2" + "]" + UNIX_NEWLINE + "[implB->dsn~name2~3" + "]",
                         itemACoveringB("implA~name1-2943155783~0", "dsn~name1~2"),

--- a/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporter.java
+++ b/importer/tag/src/test/java/org/itsallcode/openfasttrace/importer/tag/TestTagImporter.java
@@ -91,47 +91,47 @@ class TestTagImporter
                         itemACoveringB("implA~name1-2943155783~0", "dsn~name1~2"),
                         itemACoveringB("implB~name2-1099447527~0", "dsn~name2~3"),
                         itemACoveringB("implC~name3-2846888323~0", "dsn~name3~4")),
-                parsedItem("[impl~combined~1->dsn~name1~2,dsn~name2~3]",
+                parsedItem("[impl~combined~1->dsn~name1~2,dsn~name2~3" + "]",
                         itemBuilder().id(SpecificationItemId.parseId("impl~combined~1"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))),
-                parsedItem("[ impl~combined~1 -> dsn~name1~2 , dsn~name2~3 >> test ]",
+                parsedItem("[ impl~combined~1 -> dsn~name1~2 , dsn~name2~3 >> test" + "]",
                         itemBuilder().id(SpecificationItemId.parseId("impl~combined~1"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))
                                 .addNeedsArtifactType("test")),
-                parsedItem("[ impl~combined~1 -> dsn~name1~2 , dsn~name2~3 >> utest,itest ]",
+                parsedItem("[ impl~combined~1 -> dsn~name1~2 , dsn~name2~3 >> utest,itest" + "]",
                         itemBuilder().id(SpecificationItemId.parseId("impl~combined~1"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))
                                 .addNeedsArtifactType("utest")
                                 .addNeedsArtifactType("itest")),
 
-                parsedItems("[ impl~~1 -> dsn~name1~2 , dsn~name2~3 ]",
+                parsedItems("[ impl~~1 -> dsn~name1~2 , dsn~name2~3" + "]",
                         itemBuilder().id(SpecificationItemId.parseId("impl~name1-2943155783~1"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name1~2")),
                         itemBuilder().id(SpecificationItemId.parseId("impl~name2-3660411016~1"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))),
-                parsedItems("[ impl -> dsn~name1~2 , dsn~name2~3 ]",
+                parsedItems("[ impl -> dsn~name1~2 , dsn~name2~3" + "]",
                         itemBuilder().id(SpecificationItemId.parseId("impl~name1-2943155783~0"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name1~2")),
                         itemBuilder().id(SpecificationItemId.parseId("impl~name2-3660411016~0"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))),
-                parsedItems("[ impl~~1 -> dsn~name1~2 , dsn~name2~3 >> test ]",
+                parsedItems("[ impl~~1 -> dsn~name1~2 , dsn~name2~3 >> test" + "]",
                         itemBuilder().id(SpecificationItemId.parseId("impl~name1~1"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
                                 .addNeedsArtifactType("test"),
                         itemBuilder().id(SpecificationItemId.parseId("impl~name2~1"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))
                                 .addNeedsArtifactType("test")),
-                parsedItems("[ impl -> dsn~name1~2 , dsn~name2~3 >> test ]",
+                parsedItems("[ impl -> dsn~name1~2 , dsn~name2~3 >> test" + "]",
                         itemBuilder().id(SpecificationItemId.parseId("impl~name1~0"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
                                 .addNeedsArtifactType("test"),
                         itemBuilder().id(SpecificationItemId.parseId("impl~name2~0"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))
                                 .addNeedsArtifactType("test")),
-                parsedItems("[ impl~~1 -> dsn~name1~2 , dsn~name2~3 >> utest,itest ]",
+                parsedItems("[ impl~~1 -> dsn~name1~2 , dsn~name2~3 >> utest,itest" + "]",
                         itemBuilder().id(SpecificationItemId.parseId("impl~name1~1"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
                                 .addNeedsArtifactType("utest")
@@ -140,7 +140,7 @@ class TestTagImporter
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name2~3"))
                                 .addNeedsArtifactType("utest")
                                 .addNeedsArtifactType("itest")),
-                parsedItems("[ impl -> dsn~name1~2 , dsn~name2~3 >> utest,itest ]",
+                parsedItems("[ impl -> dsn~name1~2 , dsn~name2~3 >> utest,itest" + "]",
                         itemBuilder().id(SpecificationItemId.parseId("impl~name1~0"))
                                 .addCoveredId(SpecificationItemId.parseId("dsn~name1~2"))
                                 .addNeedsArtifactType("utest")


### PR DESCRIPTION
This PR enhances tags to define multiple covered ids in a tag.

ChatGPT 5.4 has been used for the first draft of the implementation and for the test.
The test was in almost in a good condition. The implementation has been heavily refactored after generation.

Documentation is written manually.