### PR TITLE
#582: Fix Markdown importer dropping items after a code block following a title

### DIFF
--- a/doc/changes/changes_4.10.0.md
+++ b/doc/changes/changes_4.10.0.md
@@ -12,6 +12,10 @@ Each release now includes an SPDX 3 SBOM for the product JAR and a SHA-256 check
 
 * #542: CI and releases now provide an SPDX 3 SBOM.
 
+## Bugfixes
+
+* #582: Fixed the Markdown importer silently dropping all specification items after a fenced code block that directly follows a section title.
+
 ## Documentation
 
 * #579: Documented planned deprecations and removals.

--- a/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MarkdownImporter.java
+++ b/importer/markdown/src/main/java/org/itsallcode/openfasttrace/importer/markdown/MarkdownImporter.java
@@ -63,6 +63,7 @@ class MarkdownImporter extends AbstractLightWeightMarkupImporter
                 transition(TITLE      , TITLE      , MdPattern.UNDERLINE  , () -> {}                           ),
                 transition(TITLE      , TITLE      , MdPattern.EMPTY      , () -> {}                           ),
                 transition(TITLE      , START      , MdPattern.FORWARD    , () -> {forward(); resetTitle();}   ),
+                transition(TITLE      , CODE_BLOCK , MdPattern.CODE_BEGIN , this::resetTitle                   ),
                 transition(TITLE      , START      , MdPattern.EVERYTHING , this::resetTitle                   ),
 
                 transition(SPEC_ITEM  , SPEC_ITEM  , MdPattern.ID         , this::beginItem                    ),

--- a/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/TestMarkdownMarkupImporter.java
+++ b/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/TestMarkdownMarkupImporter.java
@@ -254,11 +254,18 @@ class TestMarkdownMarkupImporter extends AbstractLightWeightMarkupImporterTest
                 ```
 
                 `req~example~1`
+
+                `req~example~2`
                 """,
-                contains(item()
-                        .id(SpecificationItemId.parseId("req~example~1"))
-                        .location("code_block_after_title.md", 8)
-                        .build()));
+                contains(
+                        item()
+                                .id(SpecificationItemId.parseId("req~example~1"))
+                                .location("code_block_after_title.md", 8)
+                                .build(),
+                        item()
+                                .id(SpecificationItemId.parseId("req~example~2"))
+                                .location("code_block_after_title.md", 10)
+                                .build()));
     }
 
     @ParameterizedTest

--- a/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/TestMarkdownMarkupImporter.java
+++ b/importer/markdown/src/test/java/org/itsallcode/openfasttrace/importer/markdown/TestMarkdownMarkupImporter.java
@@ -242,6 +242,25 @@ class TestMarkdownMarkupImporter extends AbstractLightWeightMarkupImporterTest
                 emptyIterable());
     }
 
+    @Test
+    void testWhenCodeBlockDirectlyFollowsTitleThenFollowingSpecificationItemMustBeDetected()
+    {
+        assertImport("code_block_after_title.md", """
+                ## A diagram before any requirement
+
+                ```mermaid
+                graph TD
+                  A --> B
+                ```
+
+                `req~example~1`
+                """,
+                contains(item()
+                        .id(SpecificationItemId.parseId("req~example~1"))
+                        .location("code_block_after_title.md", 8)
+                        .build()));
+    }
+
     @ParameterizedTest
     @CsvSource(
     {


### PR DESCRIPTION
Fixes #582: a fenced code block whose opening fence directly follows a section title made the importer silently drop every specification item after the block, because the `TITLE` state had no `CODE_BEGIN` transition and the closing fence then opened a phantom code block. This adds the missing `TITLE → CODE_BLOCK` transition, a regression test (verified to fail without the fix), and a changelog entry.

AI assistance note: analysis, fix, and test were written with Claude Code and reviewed by me; `mvn -T 1C verify` (incl. self-trace) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Hgw7DCVCJ6hEmxYz5cU8K
