### PR TITLE
Add "overview" report verbosity mode to the plain-text reporter

### DIFF
--- a/.agents/skills/openfasttrace/SKILL.md
+++ b/.agents/skills/openfasttrace/SKILL.md
@@ -110,7 +110,7 @@ General form: `oft <command> [options] <files/dirs>`
   - `-f, --output-file`: File path (default STDOUT).
   - `-a, --wanted-artifact-types`: Filter by type (Partial Tracing).
   - `-t, --wanted-tags`: Filter by tags (Partial Tracing). Use `_` for items without tags (e.g., `-t _,MyTag`).
-  - `-v, --report-verbosity`: `quiet`, `minimal`, `summary`, `failures`, `failure_summaries`, `failure_details` (default), `all`.
+  - `-v, --report-verbosity`: `quiet`, `minimal`, `summary`, `failures`, `failure_summaries`, `failure_details` (default), `overview`, `all`.
   - `-i, --ignore-artifact-types`: Exclude types from import.
 
 ### Maven Integration

--- a/api/src/main/java/org/itsallcode/openfasttrace/api/report/ReportVerbosity.java
+++ b/api/src/main/java/org/itsallcode/openfasttrace/api/report/ReportVerbosity.java
@@ -25,6 +25,8 @@ public enum ReportVerbosity
     FAILURE_DETAILS,
     /** Details of non-transitive unclean items */
     DIRECT_FAILURE_DETAILS,
+    /** Details for all items, without the specification item description */
+    OVERVIEW,
     /** Details for all items */
     ALL
     //@formatter:on

--- a/core/src/main/resources/usage.txt
+++ b/core/src/main/resources/usage.txt
@@ -14,7 +14,7 @@ Tracing options:
                                "minimal", "summary", "failures",
                                "direct_failures", "failure_summaries",
                                "direct_failure_summaries", "failure_details",
-                               "direct_failure_details", "all".
+                               "direct_failure_details", "overview", "all".
                                Defaults to "failure_details"
   --details-section-display status
                                Initial display status of the details section

--- a/doc/changes/changes_4.10.0.md
+++ b/doc/changes/changes_4.10.0.md
@@ -11,6 +11,7 @@ Each release now includes an SPDX 3 SBOM for the product JAR and a SHA-256 check
 ## Feature
 
 * #542: CI and releases now provide an SPDX 3 SBOM.
+* #589: Add "overview" report verbosity mode to the plain-text reporter
 
 ## Bugfixes
 

--- a/doc/spec/design.md
+++ b/doc/spec/design.md
@@ -612,6 +612,17 @@ Covers:
 
 Needs: impl, utest
 
+### Verbosity Level Overview
+`dsn~reporting.verbosity.overview~1`
+
+The verbosity level `overview` renders summaries, link details and tags for all items, omitting their description.
+
+Covers:
+
+* `req~reporting.verbosity.overview~1`
+
+Needs: impl, utest
+
 ## Tracing Reports
 
 ### Plain Text Report

--- a/doc/spec/system_requirements.md
+++ b/doc/spec/system_requirements.md
@@ -718,6 +718,17 @@ Covers:
 
 Needs: dsn
 
+##### Report Verbosity Overview
+`req~reporting.verbosity.overview~1`
+
+The verbosity level `overview` lists summaries, link details and tags of all specification items, without their description.
+
+Covers:
+
+* [feat~plain-text-report~1](#plain-text-report)
+
+Needs: dsn
+
 #### Plain Text Report
 The plain text report is the most basic report variant. It serves two main purposes:
 

--- a/doc/user_guide/user_guide.md
+++ b/doc/user_guide/user_guide.md
@@ -648,6 +648,7 @@ The verbosity of the tracing report.
 * `direct_failure_summaries` - list of summaries for specification items with non-transitive defects
 * `failure_details` - summaries and details for defect specification items
 * `direct_failure_details` - summaries and details for specification items with non-transitive defects
+* `overview` - summaries, link details and tags for all specification items, without the description
 * `all` - summaries and details for all specification items
 
 Defaults to `failure_details`.

--- a/reporter/plaintext/src/main/java/org/itsallcode/openfasttrace/report/plaintext/PlainTextReport.java
+++ b/reporter/plaintext/src/main/java/org/itsallcode/openfasttrace/report/plaintext/PlainTextReport.java
@@ -104,6 +104,11 @@ public class PlainTextReport implements Reportable
             report.print(this.settings.getNewline());
             renderSummary(report);
             break;
+        case OVERVIEW:
+            renderOverview(report, this.settings.showOrigin());
+            report.print(this.settings.getNewline());
+            renderSummary(report);
+            break;
         default:
             throw new IllegalStateException("Unable to create stream for unknown verbosity level "
                     + this.settings.getReportVerbosity());
@@ -298,7 +303,7 @@ public class PlainTextReport implements Reportable
     {
         this.trace.getDefectItems().stream() //
                 .sorted(LINKED_ITEM_BY_ID) //
-                .forEachOrdered(item -> renderItemDetails(report, item, showOrigin));
+                .forEachOrdered(item -> renderItemDetails(report, item, showOrigin, true));
     }
 
     // [impl->dsn~reporting.verbosity.direct-failure-details~1]
@@ -307,21 +312,32 @@ public class PlainTextReport implements Reportable
         this.trace.getDefectItems().stream() //
                 .filter(PlainTextReport::isDirectDefect) //
                 .sorted(LINKED_ITEM_BY_ID) //
-                .forEachOrdered(item -> renderItemDetails(report, item, showOrigin));
+                .forEachOrdered(item -> renderItemDetails(report, item, showOrigin, true));
     }
 
     private void renderAll(final PrintStream report, final boolean showOrigin)
     {
         this.trace.getItems().stream() //
                 .sorted(LINKED_ITEM_BY_ID) //
-                .forEachOrdered(item -> renderItemDetails(report, item, showOrigin));
+                .forEachOrdered(item -> renderItemDetails(report, item, showOrigin, true));
+    }
+
+    // [impl->dsn~reporting.verbosity.overview~1]
+    private void renderOverview(final PrintStream report, final boolean showOrigin)
+    {
+        this.trace.getItems().stream() //
+                .sorted(LINKED_ITEM_BY_ID) //
+                .forEachOrdered(item -> renderItemDetails(report, item, showOrigin, false));
     }
 
     private void renderItemDetails(final PrintStream report, final LinkedSpecificationItem item,
-            final boolean showOrigin)
+            final boolean showOrigin, final boolean showDescription)
     {
         renderItemSummary(report, item);
-        renderDescription(report, item);
+        if (showDescription)
+        {
+            renderDescription(report, item);
+        }
         if (showOrigin)
         {
             renderOrigin(report, item);

--- a/reporter/plaintext/src/test/java/org/itsallcode/openfasttrace/report/plaintext/TestPlainTextReport.java
+++ b/reporter/plaintext/src/test/java/org/itsallcode/openfasttrace/report/plaintext/TestPlainTextReport.java
@@ -361,6 +361,32 @@ class TestPlainTextReport
                 "not ok - 2 total, 1 direct, 0 transitive defects");
     }
 
+    // [utest->dsn~reporting.verbosity.overview~1]
+    @Test
+    void testReport_LevelOverview()
+    {
+        when(this.traceMock.count()).thenReturn(2);
+        when(this.traceMock.countDefects()).thenReturn(1);
+        prepareMixedItemDetails();
+
+        assertReportOutput(ReportVerbosity.OVERVIEW, //
+                "not ok [ in:  1 /  1 ✔ | out:  2 /  4 ✘ ] dsn~failure~0 (impl, uman, -utest) [has 3 duplicates]", //
+                "", //
+                "  [covered shallow  ] ← imp~failure~0", //
+                "  [covers           ] → req~bar~1", //
+                "  [unwanted         ] → req~baz~1", //
+                "  [covers           ] → req~foo~1", //
+                "  [outdated         ] → req~zoo~1", //
+                "  [orphaned         ] → req~zoo~2", //
+                "", //
+                "ok [ in:  0 /  0   | out:  0 /  0   ] req~success~20170126 (dsn)", //
+                "", //
+                "  #: tag, another tag", //
+                "", //
+                "", //
+                "not ok - 2 total, 1 direct, 0 transitive defects");
+    }
+
     private void prepareMixedItemDetails()
     {
         final LinkedSpecificationItem itemAMock = createLinkedItemMock("req~success~20170126", //


### PR DESCRIPTION
Renders summaries, link details and tags for every traced item like "all", but omits the specification item description, for a dense overview of tracing problems without the descriptive text noise.

Related to issue #588 

Coded with the help of Claude Code (sonnet 5), following the provided guidelines.